### PR TITLE
Add CAS login flow

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
   "require" : {
     "xp-framework/core": "^10.0 | ^9.0 | ^8.0 | ^7.0",
     "xp-framework/http": "^10.0 | ^9.0 | ^8.0 | ^7.0",
+    "xp-framework/xml": "^10.0 | ^9.0 | ^8.0",
     "xp-forge/web": "^2.0 | ^1.0",
     "xp-forge/json": "^4.0 | ^3.1",
     "xp-forge/sessions": "^2.0 | ^1.0",

--- a/src/main/php/web/auth/cas/CasFlow.class.php
+++ b/src/main/php/web/auth/cas/CasFlow.class.php
@@ -1,0 +1,120 @@
+<?php namespace web\auth\cas;
+
+use peer\http\HttpConnection;
+use web\Cookie;
+use web\Error;
+use web\Filter;
+use web\auth\Flow;
+use xml\XMLFormatException;
+use xml\dom\Document;
+use xml\parser\StreamInputSource;
+use xml\parser\XMLParser;
+
+class CasFlow implements Flow {
+  const SESSION_KEY = 'cas::flow';
+
+  /**
+   * Creates a new instance with a given SSO base url and sessions implementation
+   *
+   * @param  string $sso
+   * @param  web.auth.cas.URL $url The service URL, uses request URI by default
+  */
+  public function __construct($sso, URL $url= null) {
+    $this->sso= rtrim($sso, '/');
+    $this->url= $url ?: new UseRequest();
+  }
+
+  /**
+   * Validates a CAS ticket
+   *
+   * @param  string $ticket
+   * @param  string $service
+   * @return peer.http.HttpResponse
+   */
+  protected function validate($ticket, $service) {
+    return (new HttpConnection($this->sso.'/serviceValidate'))->get([
+      'ticket'  => $ticket,
+      'service' => $service
+    ]);
+  }
+
+  /**
+   * Executes authentication flow, returning the authentication result
+   *
+   * @param  web.Request $request
+   * @param  web.Response $response
+   * @param  web.session.Session $session
+   * @return var
+   */
+  public function authenticate($request, $response, $session) {
+    $state= $session->value(self::SESSION_KEY);
+    if (isset($state['username'])) return $state;
+
+    $uri= $this->url->resolve($request);
+
+    // Validate ticket, then relocate to self without ticket parameter
+    if ($ticket= $request->param('ticket')) {
+      $service= $uri->using()->param('ticket', null)->create();
+
+      $validate= $this->validate($ticket, $service);
+      if (200 !== $validate->statusCode()) {
+        throw new Error($validate->statusCode(), $validate->message());
+      }
+
+      $result= new Document();
+      try {
+        (new XMLParser())->withCallback($result)->parse(new StreamInputSource($validate->in()));
+      } catch (XMLFormatException $e) {
+        throw new Error(500, 'FORMAT: Validation cannot be parsed', $e);
+      }
+
+      if ($failure= $result->getElementsByTagName('cas:authenticationFailure')) {
+        throw new Error(500, $failure[0]->getAttribute('code').': '.trim($failure[0]->getContent()));
+      } else if (!($success= $result->getElementsByTagName('cas:authenticationSuccess'))) {
+        throw new Error(500, 'UNEXPECTED: '.$result->getSource());
+      }
+
+      $user= ['username' => $result->getElementsByTagName('cas:user')[0]->getContent()];
+      if ($attr= $result->getElementsByTagName('cas:attributes')) {
+        foreach ($attr[0]->getChildren() as $child) {
+          $user[str_replace('cas:', '', $child->getName())]= $child->getContent();
+        }
+      }
+
+      $session->register(self::SESSION_KEY, $user);
+      $response->answer(302);
+      $response->header('Location', $service->using()->param('_', null)->fragment($request->param('_'), false)->create());
+      return;
+    }
+
+    // Send redirect using JavaScript to capture URL fragments (see issue #2).
+    // Include meta refresh in body as fallback for when JavaScript is disabled,
+    // in which case we lose the fragment, but still offer a degraded service.
+    // Do not move this to HTTP headers to ensure the body has been parsed, and
+    // the JavaScript executed!
+    $target= $this->sso.'/login?service='.urlencode($uri);
+    $redirect= sprintf('<!DOCTYPE html>
+      <html>
+        <head>
+          <title>Redirect</title>
+          <meta http-equiv="refresh" content="1; URL=%1$s">
+        </head>
+        <body>
+          <script type="text/javascript">
+            var hash = document.location.hash.substring(1);
+            if (hash) {
+              document.location.replace("%1$s" + encodeURIComponent(
+                (document.location.search ? "&=" : "?_=") +
+                encodeURIComponent(hash)
+              ));
+            } else {
+              document.location.replace("%1$s");
+            }
+          </script>
+        </body>
+      </html>',
+      $target
+    );
+    $response->send($redirect, 'text/html');
+  }
+}

--- a/src/main/php/web/auth/cas/CasFlow.class.php
+++ b/src/main/php/web/auth/cas/CasFlow.class.php
@@ -84,10 +84,17 @@ class CasFlow implements Flow {
       $session->register(self::SESSION_KEY, $user);
       $response->answer(302);
       $response->header('Location', $service->using()->param('_', null)->fragment($request->param('_'), false)->create());
-      return;
+      return null;
     }
 
-    // Send redirect using JavaScript to capture URL fragments (see issue #2).
+    // This is only for test code, real request URIs will never have a fragment
+    // as these are a purely client-side concept
+    if ($fragment= $uri->fragment()) {
+      $uri= $uri->using()->param('_', $fragment)->fragment(null)->create();
+    }
+
+    // Send redirect using JavaScript to capture URL fragments.
+    //
     // Include meta refresh in body as fallback for when JavaScript is disabled,
     // in which case we lose the fragment, but still offer a degraded service.
     // Do not move this to HTTP headers to ensure the body has been parsed, and
@@ -116,5 +123,6 @@ class CasFlow implements Flow {
       $target
     );
     $response->send($redirect, 'text/html');
+    return null;
   }
 }

--- a/src/main/php/web/auth/cas/ServiceURL.class.php
+++ b/src/main/php/web/auth/cas/ServiceURL.class.php
@@ -1,0 +1,29 @@
+<?php namespace web\auth\cas;
+
+use util\URI;
+
+/**
+ * Uses given URI as service base URL
+ */
+class ServiceURL implements URL {
+  private $uri;
+
+  /** @param util.URI|string $uri */
+  public function __construct($uri) {
+    $this->uri= $uri instanceof URI ? $uri : new URI($uri);
+  }
+  
+  /**
+   * Resolves URI
+   *
+   * @param  web.Request $request
+   * @return util.URI
+   */
+  public function resolve($request) {
+    return $this->uri->using()
+      ->path(rtrim($this->uri->path(), '/').$request->uri()->path())
+      ->query($request->uri()->query())
+      ->create()
+    ;
+  }
+}

--- a/src/main/php/web/auth/cas/ServiceURL.class.php
+++ b/src/main/php/web/auth/cas/ServiceURL.class.php
@@ -23,6 +23,7 @@ class ServiceURL implements URL {
     return $this->uri->using()
       ->path(rtrim($this->uri->path(), '/').$request->uri()->path())
       ->query($request->uri()->query())
+      ->fragment($request->uri()->fragment(), false)
       ->create()
     ;
   }

--- a/src/main/php/web/auth/cas/URL.class.php
+++ b/src/main/php/web/auth/cas/URL.class.php
@@ -1,0 +1,12 @@
+<?php namespace web\auth\cas;
+
+interface URL {
+  
+  /**
+   * Resolves URI
+   *
+   * @param  web.Request $request
+   * @return util.URI
+   */
+  public function resolve($request);
+}

--- a/src/main/php/web/auth/cas/UseRequest.class.php
+++ b/src/main/php/web/auth/cas/UseRequest.class.php
@@ -1,0 +1,17 @@
+<?php namespace web\auth\cas;
+
+/**
+ * Uses request URI as service URL
+ */
+class UseRequest implements URL {
+  
+  /**
+   * Resolves URI
+   *
+   * @param  web.Request $request
+   * @return util.URI
+   */
+  public function resolve($request) {
+    return $request->uri();
+  }
+}

--- a/src/test/php/web/auth/oauth/unittest/CasFlowTest.class.php
+++ b/src/test/php/web/auth/oauth/unittest/CasFlowTest.class.php
@@ -1,0 +1,221 @@
+<?php namespace web\auth\oauth\unittest;
+
+use io\streams\MemoryInputStream;
+use peer\http\HttpResponse;
+use unittest\{Expect, Test, TestCase, Values};
+use web\auth\cas\{CasFlow, UseRequest, ServiceURL};
+use web\io\{TestInput, TestOutput};
+use web\session\ForTesting;
+use web\{Request, Response, Error};
+
+class CasFlowTest extends TestCase {
+  const SSO     = 'https://example.com/sso/login';
+  const SERVICE = 'https://service.example.com';
+  const TICKET  = 'ST-1856339-aA5Yuvrxzpv8Tau1cYQ7';
+
+  /** @return iterable */
+  private function paths() {
+    yield ['/'];
+    yield ['/home'];
+    yield ['/~test'];
+    yield ['/?a=b'];
+    yield ['/?a=b&c=d'];
+  }
+
+  /**
+   * Asserts a given response redirects to a given SSO login
+   *
+   * @param  string $service
+   * @param  web.Response $res
+   * @throws unittest.AssertionFailedError
+   */
+  private function assertLoginWith($service, $res) {
+    preg_match('/<meta http-equiv="refresh" content="1; URL=([^"]+)">/', $res->output()->bytes(), $m);
+    $this->assertEquals(self::SSO.'/login?service='.urlencode($service), $m[1]);
+  }
+
+  /**
+   * Calls authenticate method, returning response
+   * 
+   * @param  web.auth.cas.CasLogin $fixture
+   * @param  string $path
+   * @param  web.session.ISession $session
+   * @return web.Response
+   */
+  private function authenticate($fixture, $path= '/', $session= null) {
+    $req= new Request(new TestInput('GET', $path));
+    $res= new Response(new TestOutput());
+    $fixture->authenticate($req, $res, $session ?: (new ForTesting())->create());
+    return $res;
+  }
+
+  /**
+   * Creates a validation response
+   *
+   * @param  string $xml
+   * @return peer.http.HttpResponse
+   */
+  public static function response($xml) {
+    return new HttpResponse(new MemoryInputStream(sprintf(
+      "HTTP/1.1 200 OK\r\nContent-Type: text/xml\r\nContent-Length: %d\r\n\r\n%s",
+      strlen($xml),
+      $xml
+    )));
+  }
+
+  #[Test]
+  public function can_create() {
+    new CasFlow(self::SSO);
+  }
+
+  #[Test, Values('paths')]
+  public function redirects_to_sso($path) {
+    $this->assertLoginWith(
+      'http://localhost'.$path,
+      $this->authenticate(new CasFlow(self::SSO), $path)
+    );
+  }
+
+  #[Test, Values('paths')]
+  public function redirects_to_sso_using_request($path) {
+    $this->assertLoginWith(
+      'http://localhost'.$path,
+      $this->authenticate(new CasFlow(self::SSO, new UseRequest()), $path)
+    );
+  }
+
+  #[Test, Values('paths')]
+  public function redirects_to_sso_given_service($path) {
+    $this->assertLoginWith(
+      self::SERVICE.$path,
+      $this->authenticate(new CasFlow(self::SSO, new ServiceURL(self::SERVICE)), $path)
+    );
+  }
+
+  #[Test]
+  public function validates_ticket_then_redirects_to_self() {
+    $fixture= new class(self::SSO) extends CasFlow {
+      public function validate($ticket, $service) {
+        return CasFlowTest::response('
+          <cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+            <cas:authenticationSuccess>
+              <cas:user>test</cas:user>
+            </cas:authenticationSuccess>
+          </cas:serviceResponse>
+        ');
+      }
+    };
+
+    $res= $this->authenticate($fixture, '/?ticket='.self::TICKET);
+    $this->assertEquals('http://localhost/', $res->headers()['Location']);
+  }
+
+  #[Test]
+  public function stores_user_in_session() {
+    $fixture= new class(self::SSO) extends CasFlow {
+      public function validate($ticket, $service) {
+        return CasFlowTest::response('
+          <cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+            <cas:authenticationSuccess>
+              <cas:user>test</cas:user>
+            </cas:authenticationSuccess>
+          </cas:serviceResponse>
+        ');
+      }
+    };
+    $session= (new ForTesting())->create();
+
+    $this->authenticate($fixture, '/?ticket='.self::TICKET, $session);
+    $this->assertEquals(
+      ['username' => 'test'],
+      $session->value(CasFlow::SESSION_KEY)
+    );
+  }
+
+  #[Test]
+  public function stores_additional_user_attributes_in_session() {
+    $fixture= new class(self::SSO) extends CasFlow {
+      public function validate($ticket, $service) {
+        return CasFlowTest::response('
+          <cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+            <cas:authenticationSuccess>
+              <cas:user>test</cas:user>
+              <cas:attributes>
+                <cas:givenName>John Doe</cas:givenName>
+                <cas:email>jdoe@example.org</cas:email>
+              </cas:attributes>
+            </cas:authenticationSuccess>
+          </cas:serviceResponse>
+        ');
+      }
+    };
+    $session= (new ForTesting())->create();
+
+    $this->authenticate($fixture, '/?ticket='.self::TICKET, $session);
+    $this->assertEquals(
+      ['username' => 'test', 'givenName' => 'John Doe', 'email' => 'jdoe@example.org'],
+      $session->value(CasFlow::SESSION_KEY)
+    );
+  }
+
+  #[Test]
+  public function returns_user_in_final_step() {
+    $user= ['username' => 'test'];
+
+    $fixture= new CasFlow(self::SSO);
+    $session= (new ForTesting())->create();
+    $session->register(CasFlow::SESSION_KEY, $user);
+
+    $req= new Request(new TestInput('GET', '/'));
+    $res= new Response(new TestOutput());
+    $result= $fixture->authenticate($req, $res, $session);
+
+    $this->assertEquals($user, $result);
+  }
+
+  #[Test, Expect(class: Error::class, withMessage: '/INVALID_TICKET: Ticket .+ not recognized/')]
+  public function shows_error_when_ticket_cannot_be_validated() {
+    $fixture= new class(self::SSO) extends CasFlow {
+      public function validate($ticket, $service) {
+        return CasFlowTest::response('
+          <cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+            <cas:authenticationFailure code="INVALID_TICKET">
+              Ticket ST-1856339-aA5Yuvrxzpv8Tau1cYQ7 not recognized`
+            </cas:authenticationFailure>
+          </cas:serviceResponse>
+        ');
+      }
+    };
+
+    $this->authenticate($fixture, '/?ticket='.self::TICKET);
+  }
+
+  #[Test, Expect(class: Error::class, withMessage: '/UNEXPECTED: .+/')]
+  public function shows_error_when_validation_response_invalid() {
+    $fixture= new class(self::SSO) extends CasFlow {
+      public function validate($ticket, $service) {
+        return CasFlowTest::response('
+          <cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+            <!-- Empty -->
+          </cas:serviceResponse>
+        ');
+      }
+    };
+
+    $this->authenticate($fixture, '/?ticket='.self::TICKET);
+  }
+
+  #[Test, Expect(class: Error::class, withMessage: '/FORMAT: Validation cannot be parsed/')]
+  public function shows_error_when_validation_response_not_well_formed() {
+    $fixture= new class(self::SSO) extends CasFlow {
+      public function validate($ticket, $service) {
+        return CasFlowTest::response('
+          <cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+          </cas:NOT_WELL_FORMED>
+        ');
+      }
+    };
+
+    $this->authenticate($fixture, '/?ticket='.self::TICKET);
+  }
+}

--- a/src/test/php/web/auth/oauth/unittest/CasFlowTest.class.php
+++ b/src/test/php/web/auth/oauth/unittest/CasFlowTest.class.php
@@ -9,7 +9,7 @@ use web\session\ForTesting;
 use web\{Request, Response, Error};
 
 class CasFlowTest extends TestCase {
-  const SSO     = 'https://example.com/sso/login';
+  const SSO     = 'https://example.com/sso';
   const SERVICE = 'https://service.example.com';
   const TICKET  = 'ST-1856339-aA5Yuvrxzpv8Tau1cYQ7';
 


### PR DESCRIPTION
Integrates [xp-forge/auth-cas](https://github.com/xp-forge/auth-cas) library, making it obsolete

Example:
```php
use web\auth\Authentication;
use web\auth\cas\CasFlow;
use web\session\ForTesting;
use web\Filters;

$flow= new CasFlow('https://sso.example.com/');
$auth= new Authentication($flow, new ForTesting());

return ['/' => new Filters([$auth], function($req, $res) {
  $res->send('Hello @'.$req->value('user')['username'], 'text/html');
})];
```

To map users to your own database, pass a lookup function. The following example shows how a local user entry is created upon login if not already present:

```php
$auth= new Authentication($flow, new ForTesting(), function($user) use($users) {
  return $users->named($user['username']) ?? $users->create($user);
});
```

The service URL is calculated from the request URI by default. However, if the service is behind a reverse proxy, the front-facing URL needs to be passed in.

```php
use web\auth\cas\{CasFlow, ServiceURL};

$login= new CasLogin('https://sso.example.com/', new ServiceURL('https://app.example.com/'));
```
