### PR TITLE
Add Authentication::required()

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Authentication via Twitter:
 use web\auth\Authentication;
 use web\auth\oauth\OAuth1Flow;
 use web\session\ForTesting;
-use web\Filters;
 
 $flow= new OAuth1Flow('https://api.twitter.com/oauth', [
   $credentials->named('twitter_oauth_key'),
@@ -27,7 +26,7 @@ $auth= new Authentication($flow, new ForTesting(), function($session) {
   return $session->fetch('https://api.twitter.com/1.1/account/verify_credentials.json')->value();
 });
 
-return ['/' => new Filters([$auth], function($req, $res) {
+return ['/' => $auth->required(function($req, $res) {
   $res->send('Hello @'.$req->value('user')['screen_name'], 'text/html');
 })];
 ```
@@ -38,7 +37,6 @@ Authentication via GitHub:
 use web\auth\Authentication;
 use web\auth\oauth\OAuth2Flow;
 use web\session\ForTesting;
-use web\Filters;
 
 $flow= new OAuth2Flow(
   'https://github.com/login/oauth/authorize',
@@ -49,7 +47,7 @@ $auth= new Authentication($flow, new ForTesting(), function($session) {
   return $session->fetch('https://api.github.com/user')->value();
 });
 
-return ['/' => new Filters([$auth], function($req, $res) {
+return ['/' => $auth->required(function($req, $res) {
   $res->send('Hello @'.$req->value('user')['login'], 'text/html');
 })];
 ```
@@ -60,12 +58,11 @@ Authentication via [CAS](https://apereo.github.io/cas) ("Central Authentication 
 use web\auth\Authentication;
 use web\auth\cas\CasFlow;
 use web\session\ForTesting;
-use web\Filters;
 
 $flow= new CasFlow('https://sso.example.com/');
 $auth= new Authentication($flow, new ForTesting());
 
-return ['/' => new Filters([$auth], function($req, $res) {
+return ['/' => $auth->required(function($req, $res) {
   $res->send('Hello @'.$req->value('user')['username'], 'text/html');
 })];
 ```

--- a/src/main/php/web/auth/Authentication.class.php
+++ b/src/main/php/web/auth/Authentication.class.php
@@ -1,7 +1,7 @@
 <?php namespace web\auth;
 
-use web\Filter;
 use web\session\Sessions;
+use web\{Filter, Filters};
 
 class Authentication implements Filter {
   private $flow, $sessions, $lookup;
@@ -17,6 +17,16 @@ class Authentication implements Filter {
     $this->flow= $flow;
     $this->sessions= $sessions;
     $this->lookup= $lookup;
+  }
+
+  /**
+   * Require authentication for a given handler
+   *
+   * @param  web.Handler|function(web.Request, web.Response): var $handler
+   * @return web.Handler
+   */
+  public function required($handler) {
+    return new Filters([$this], $handler);
   }
 
   /**

--- a/src/test/php/web/auth/oauth/unittest/AuthenticationTest.class.php
+++ b/src/test/php/web/auth/oauth/unittest/AuthenticationTest.class.php
@@ -1,0 +1,33 @@
+<?php namespace web\auth\oauth\unittest;
+
+use unittest\Assert;
+use web\Handler;
+use web\auth\{Authentication, Flow};
+use web\session\ForTesting;
+
+class AuthenticationTest {
+  private $sessions, $flow;
+
+  #[Before]
+  public function setUp() {
+    $this->sessions= new ForTesting();
+    $this->flow= new class() implements Flow {
+      public function authenticate($req, $res, $invocation) {
+        // ...
+      }
+    };
+  }
+
+  #[Test]
+  public function can_create() {
+    new Authentication($this->flow, $this->sessions);
+  }
+
+  #[Test]
+  public function required() {
+    $auth= new Authentication($this->flow, $this->sessions);
+    Assert::instance(Handler::class, $auth->required(function($req, $res) {
+      // ...
+    }));
+  }
+}

--- a/src/test/php/web/auth/unittest/AuthenticationTest.class.php
+++ b/src/test/php/web/auth/unittest/AuthenticationTest.class.php
@@ -1,4 +1,4 @@
-<?php namespace web\auth\oauth\unittest;
+<?php namespace web\auth\unittest;
 
 use unittest\Assert;
 use web\Handler;

--- a/src/test/php/web/auth/unittest/CasFlowTest.class.php
+++ b/src/test/php/web/auth/unittest/CasFlowTest.class.php
@@ -1,4 +1,4 @@
-<?php namespace web\auth\oauth\unittest;
+<?php namespace web\auth\unittest;
 
 use io\streams\MemoryInputStream;
 use peer\http\HttpResponse;

--- a/src/test/php/web/auth/unittest/OAuth1FlowTest.class.php
+++ b/src/test/php/web/auth/unittest/OAuth1FlowTest.class.php
@@ -1,4 +1,4 @@
-<?php namespace web\auth\oauth\unittest;
+<?php namespace web\auth\unittest;
 
 use lang\IllegalStateException;
 use unittest\Assert;

--- a/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
+++ b/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
@@ -1,4 +1,4 @@
-<?php namespace web\auth\oauth\unittest;
+<?php namespace web\auth\unittest;
 
 use lang\IllegalStateException;
 use unittest\Assert;

--- a/src/test/php/web/auth/unittest/ResponseTest.class.php
+++ b/src/test/php/web/auth/unittest/ResponseTest.class.php
@@ -1,4 +1,4 @@
-<?php namespace web\auth\oauth\unittest;
+<?php namespace web\auth\unittest;
 
 use io\streams\{MemoryInputStream, Streams};
 use lang\FormatException;


### PR DESCRIPTION
Makes the setup code slightly simpler:

```php
$auth= new Authentication(...);

// Before
return ['/' => new Filters([$auth], function($req, $res) {
  $res->send('Hello @'.$req->value('user')['screen_name'], 'text/html');
})];

// After, can also drop web\Filters from imports
return ['/' => $auth->required(function($req, $res) {
  $res->send('Hello @'.$req->value('user')['screen_name'], 'text/html');
})];