### PR TITLE
Fix callback URL mismatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ use web\auth\SessionBased;
 use web\auth\oauth\OAuth1Flow;
 use web\session\ForTesting;
 
-$flow= new OAuth1Flow('https://api.twitter.com/oauth', [
-  $credentials->named('twitter_oauth_key'),
-  $credentials->named('twitter_oauth_secret'),
-]);
+$flow= new OAuth1Flow(
+  'https://api.twitter.com/oauth',
+  [$credentials->named('twitter_oauth_key'), $credentials->named('twitter_oauth_secret')],
+  $callback
+);
 $auth= new SessionBased($flow, new ForTesting(), function($client) {
   return $client->fetch('https://api.twitter.com/1.1/account/verify_credentials.json')->value();
 });
@@ -45,6 +46,8 @@ return ['/' => $auth->required(function($req, $res) {
   $res->send('Hello @'.$req->value('user')['screen_name'], 'text/html');
 })];
 ```
+
+*The $callback parameter should be the path matching the path in the callback URI registered with Twitter.*
 
 Authentication via GitHub:
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ $flow= new OAuth2Flow(
   'https://github.com/login/oauth/authorize',
   'https://github.com/login/oauth/access_token',
   [$credentials->named('github_oauth_key'), $credentials->named('github_oauth_secret')],
+  $callback
 );
 $auth= new SessionBased($flow, new ForTesting(), function($client) {
   return $client->fetch('https://api.github.com/user')->value();
@@ -66,6 +67,8 @@ return ['/' => $auth->required(function($req, $res) {
   $res->send('Hello @'.$req->value('user')['login'], 'text/html');
 })];
 ```
+
+*The $callback parameter should be the path matching the path in the callback URI registerd with the service.*
 
 Authentication via [CAS](https://apereo.github.io/cas) ("Central Authentication Service"):
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ return ['/' => $auth->required(function($req, $res) {
 })];
 ```
 
-*The $callback parameter should be the path matching the path in the callback URI registerd with the service.*
+*The $callback parameter should be the path matching the path in the callback URI registered with GitHub.*
 
 Authentication via [CAS](https://apereo.github.io/cas) ("Central Authentication Service"):
 

--- a/src/main/php/web/auth/Flow.class.php
+++ b/src/main/php/web/auth/Flow.class.php
@@ -45,47 +45,6 @@ abstract class Flow {
   }
 
   /**
-   * Send redirect using JavaScript to capture URL fragments. This is so that
-   * sites using URLs like `/#/users/123` will not redirect to "/" when requiring
-   * authentication. Uses `_` as special parameter name.
-   *
-   * @param  web.Response $response
-   * @param  string|util.URI $target
-   * @return void
-   */
-  protected function login($response, $target) {
-
-    // Include meta refresh in body as fallback for when JavaScript is disabled,
-    // in which case we lose the fragment, but still offer a degraded service.
-    // Do not move this to HTTP headers to ensure the body has been parsed, and
-    // the JavaScript executed!
-    $redirect= sprintf('<!DOCTYPE html>
-      <html>
-        <head>
-          <title>Redirect</title>
-          <meta http-equiv="refresh" content="1; URL=%1$s">
-        </head>
-        <body>
-          <script type="text/javascript">
-            var hash = document.location.hash.substring(1);
-            if (hash) {
-              document.location.replace("%1$s" + encodeURIComponent(
-                (document.location.search ? "&%2$s=" : "?%2$s=") +
-                encodeURIComponent(hash)
-              ));
-            } else {
-              document.location.replace("%1$s");
-            }
-          </script>
-        </body>
-      </html>',
-      $target,
-      self::FRAGMENT
-    );
-    $response->send($redirect, 'text/html');
-  }
-
-  /**
    * Final redirect, replacing `_` parameter back with fragment if present
    *
    * @param  web.Response $response

--- a/src/main/php/web/auth/Flow.class.php
+++ b/src/main/php/web/auth/Flow.class.php
@@ -1,9 +1,11 @@
 <?php namespace web\auth;
 
+use util\URI;
+
 abstract class Flow {
   const FRAGMENT = '_';
 
-  private $url;
+  private $url= null;
 
   /**
    * Targets a given URL
@@ -87,16 +89,17 @@ abstract class Flow {
    * Final redirect, replacing `_` parameter back with fragment if present
    *
    * @param  web.Response $response
-   * @param  util.URI $service
+   * @param  string|util.URI $target
    * @return void
    */
-  protected function finalize($response, $service) {
-    if ($fragment= $service->param(self::FRAGMENT)) {
-      $service= $service->using()->param(self::FRAGMENT, null)->fragment($fragment, false)->create();
-    }
+  protected function finalize($response, $target) {
+    $uri= $target instanceof URI ? $target : new URI($target);
 
     $response->answer(302);
-    $response->header('Location', $service);
+    $response->header('Location', ($fragment= $uri->param(self::FRAGMENT))
+      ? $uri->using()->param(self::FRAGMENT, null)->fragment($fragment, false)->create()
+      : $uri
+    );
   }
 
   /**

--- a/src/main/php/web/auth/Flow.class.php
+++ b/src/main/php/web/auth/Flow.class.php
@@ -45,6 +45,36 @@ abstract class Flow {
   }
 
   /**
+   * Perfoms redirection by rendering an HTML page with a given script on it. This
+   * is so that sites using URLs like `/#/users/123` will not redirect to "/" when
+   * requiring authentication.
+   *
+   * Includes a meta refresh in head as fallback for when JavaScript is disabled,
+   * in which case we lose the fragment, but still offer a degraded service.
+   *
+   * @param  web.Response $response
+   * @param  string|util.URI $target
+   * @param  string $script
+   * @return void
+   */
+  protected function redirect($response, $target, $script) {
+    $redirect= sprintf('<!DOCTYPE html>
+      <html>
+        <head>
+          <title>Redirect</title>
+          <noscript><meta http-equiv="refresh" content="0; URL=%1$s"></noscript>
+        </head>
+        <body>
+          <script type="text/javascript">%2$s</script>
+        </body>
+      </html>',
+      $target,
+      $script
+    );
+    $response->send($redirect, 'text/html');
+  }
+
+  /**
    * Final redirect, replacing `_` parameter back with fragment if present
    *
    * @param  web.Response $response

--- a/src/main/php/web/auth/cas/CasFlow.class.php
+++ b/src/main/php/web/auth/cas/CasFlow.class.php
@@ -37,6 +37,44 @@ class CasFlow extends Flow {
   }
 
   /**
+   * Send redirect using JavaScript to capture URL fragments. This is so that
+   * sites using URLs like `/#/users/123` will not redirect to "/" when requiring
+   * authentication. Uses `_` as special parameter name. Include meta refresh in
+   * head as fallback for when JavaScript is disabled, in which case we lose the
+   * fragment, but still offer a degraded service.
+   *
+   * @param  web.Response $response
+   * @param  string|util.URI $target
+   * @return void
+   */
+  private function redirect($response, $target) {
+    $redirect= sprintf('<!DOCTYPE html>
+      <html>
+        <head>
+          <title>Redirect</title>
+          <noscript><meta http-equiv="refresh" content="0; URL=%1$s"></noscript>
+        </head>
+        <body>
+          <script type="text/javascript">
+            var hash = document.location.hash.substring(1);
+            if (hash) {
+              document.location.replace("%1$s" + encodeURIComponent(
+                (document.location.search ? "&%2$s=" : "?%2$s=") +
+                encodeURIComponent(hash)
+              ));
+            } else {
+              document.location.replace("%1$s");
+            }
+          </script>
+        </body>
+      </html>',
+      $target,
+      self::FRAGMENT
+    );
+    $response->send($redirect, 'text/html');
+  }
+
+  /**
    * Executes authentication flow, returning the authentication result
    *
    * @param  web.Request $request
@@ -52,7 +90,7 @@ class CasFlow extends Flow {
     // then finalize this flow by relocating to self without ticket parameter.
     $uri= $this->url(true)->resolve($request);
     if (null === ($ticket= $request->param('ticket'))) {
-      $this->login($response, $this->sso.'/login?service='.urlencode($this->service($uri)));
+      $this->redirect($response, $this->sso.'/login?service='.urlencode($this->service($uri)));
       return null;
     }
 

--- a/src/main/php/web/auth/oauth/OAuth1Flow.class.php
+++ b/src/main/php/web/auth/oauth/OAuth1Flow.class.php
@@ -121,10 +121,10 @@ class OAuth1Flow extends Flow {
 
     // Store fragment, then make redirection continue (see redirect() above)
     if ($fragment= $request->param(self::FRAGMENT)) {
-      if (false === ($p= strpos($state['target'], '#'))) {
-        $state['target'].= '#'.$fragment;
+      if ($t= strstr($state['target'], '#', true)) {
+        $state['target']= $t.'#'.$fragment;
       } else {
-        $state['target']= substr($state['target'], 0, $p + 1).$fragment;
+        $state['target'].= '#'.$fragment;
       }
 
       $session->register(self::SESSION_KEY, $state);

--- a/src/main/php/web/auth/oauth/OAuth1Flow.class.php
+++ b/src/main/php/web/auth/oauth/OAuth1Flow.class.php
@@ -31,6 +31,9 @@ class OAuth1Flow extends Flow {
     }
   }
 
+  /** @return ?util.URI */
+  public function callback() { return $this->callback; }
+
   /**
    * Obtain a request token
    *

--- a/src/main/php/web/auth/oauth/OAuth1Flow.class.php
+++ b/src/main/php/web/auth/oauth/OAuth1Flow.class.php
@@ -66,7 +66,9 @@ class OAuth1Flow extends Flow {
    * If a URL fragment is present, call ourselves to capture it inside the
    * session; otherwise redirect the OAuth authentication service directly.
    * This is necessary as otherwise the fragment would be lost, resulting
-   * in the user arriving at the site she expected.
+   * in the user arriving at the site she expected. Include meta refresh in
+   * head as fallback for when JavaScript is disabled, in which case we lose
+   * the fragment, but still offer a degraded service.
    *
    * @param  web.Response $response
    * @param  string $self Our own URI
@@ -78,7 +80,7 @@ class OAuth1Flow extends Flow {
       <html>
         <head>
           <title>Redirect</title>
-          <noscript><meta http-equiv="refresh" content="1; URL=%1$s"></noscript>
+          <noscript><meta http-equiv="refresh" content="0; URL=%1$s"></noscript>
         </head>
         <body>
           <script type="text/javascript">

--- a/src/main/php/web/auth/oauth/OAuth2Flow.class.php
+++ b/src/main/php/web/auth/oauth/OAuth2Flow.class.php
@@ -10,7 +10,7 @@ use web\session\Sessions;
 class OAuth2Flow extends Flow {
   const SESSION_KEY = 'oauth2::flow';
 
-  private $auth, $tokens, $consumer, $scopes, $rand;
+  private $auth, $tokens, $consumer, $scopes, $callback, $rand;
 
   /**
    * Creates a new OAuth 2 flow
@@ -18,15 +18,29 @@ class OAuth2Flow extends Flow {
    * @param  string|util.URI $auth
    * @param  string|util.URI $tokens
    * @param  web.auth.oauth.Token|string[]|util.Secret[] $consumer
+   * @param  string|util.URI $callback
    * @param  string[] $scopes
    */
-  public function __construct($auth, $tokens, $consumer, $scopes= ['user']) {
+  public function __construct($auth, $tokens, $consumer, $callback= null, $scopes= ['user']) {
     $this->auth= $auth instanceof URI ? $auth : new URI($auth);
     $this->tokens= $tokens instanceof URI ? $tokens : new URI($tokens);
     $this->consumer= $consumer instanceof Token ? $consumer : new Token(...$consumer);
-    $this->scopes= $scopes;
+
+    // BC: Support deprecated constructor signature without callback
+    if (is_array($callback) || null === $callback) {
+      trigger_error('Missing parameter $callback', E_USER_DEPRECATED);
+      $this->callback= null;
+      $this->scopes= $callback ?? $scopes;
+    } else {
+      $this->callback= $callback instanceof URI ? $callback : new URI($callback);
+      $this->scopes= $scopes;
+    }
+
     $this->rand= new Random();
   }
+
+  /** @return ?util.URI */
+  public function callback() { return $this->callback; }
 
   /** @return string[] */
   public function scopes() { return $this->scopes; }
@@ -68,19 +82,21 @@ class OAuth2Flow extends Flow {
    * @throws lang.IllegalStateException
    */
   public function authenticate($request, $response, $session) {
-    $state= $session->value(self::SESSION_KEY);
+    $stored= $session->value(self::SESSION_KEY);
 
     // We have an access token, return an authenticated session
-    if (isset($state['access_token'])) {
-      return new ByAccessToken($state['access_token'], $state['token_type']);
+    if (isset($stored['access_token'])) {
+      return new ByAccessToken($stored['access_token'], $stored['token_type']);
     }
 
-    // Start authorization flow to acquire an access token
     $uri= $this->url(true)->resolve($request);
+    $callback= $this->callback ? $uri->resolve($this->callback) : $this->service($uri);
+
+    // Start authorization flow to acquire an access token
     $server= $request->param('state');
-    if (null === $state || null === $server) {
+    if (null === $stored || null === $server) {
       $state= bin2hex($this->rand->bytes(16));
-      $session->register(self::SESSION_KEY, $state);
+      $session->register(self::SESSION_KEY, ['state' => $state, 'target' => (string)$uri]);
       $session->transmit($response);
 
       // Redirect the user to the authorization page
@@ -88,13 +104,17 @@ class OAuth2Flow extends Flow {
         'response_type' => 'code',
         'client_id'     => $this->consumer->key()->reveal(),
         'scope'         => implode(' ', $this->scopes),
+        'redirect_uri'  => $callback,
         'state'         => $state,
-        'redirect_uri'  => $this->service($uri),
       ]);
 
       $this->login($response, $target->create());
       return null;
-    } else if ($server === $state) {
+    }
+
+    // Continue authorization flow
+    $state= explode('?', $server);
+    if ($state[0] === $stored['state']) {
 
       // Exchange the auth code for an access token
       $token= $this->token([
@@ -102,19 +122,20 @@ class OAuth2Flow extends Flow {
         'client_id'     => $this->consumer->key()->reveal(),
         'client_secret' => $this->consumer->secret()->reveal(),
         'code'          => $request->param('code'),
-        'state'         => $state,
-        'redirect_uri'  => $uri->using()->params([])->create(),
+        'redirect_uri'  => $callback,
+        'state'         => $stored['state'],
       ]);
       $session->register(self::SESSION_KEY, $token);
       $session->transmit($response);
 
-      // Redirect to self, getting rid of OAuth request parameters
-      $params= $request->params();
-      unset($params['state'], $params['code'], $params['session_state']);
-      $this->finalize($response, $uri->using()->params($params)->create());
+      // Redirect to self, using encoded fragment parameter if present
+      $this->finalize($response, $stored['target'].(isset($state[1])
+        ? '#'.urldecode(substr($state[1], strlen(self::FRAGMENT) + 1))
+        : ''
+      ));
       return null;
     }
 
-    throw new IllegalStateException('Flow error, session state '.$state.' != server state '.$server);
+    throw new IllegalStateException('Flow error, session state '.$stored['state'].' != server state '.$state[0]);
   }
 }

--- a/src/main/php/web/auth/oauth/OAuth2Flow.class.php
+++ b/src/main/php/web/auth/oauth/OAuth2Flow.class.php
@@ -53,12 +53,10 @@ class OAuth2Flow extends Flow {
    * @throws lang.IllegalStateException
    */
   protected function token($payload) {
-    // \util\cmd\Console::writeLine('>>> ', $payload);
     $c= new HttpConnection($this->tokens);
     $r= $c->post($payload, ['Accept' => 'application/x-www-form-urlencoded, application/json', 'User-Agent' => 'XP/OAuth2']);
-    $body= Streams::readAll($r->in());
-    // \util\cmd\Console::writeLine('<<< ', $body);
 
+    $body= Streams::readAll($r->in());
     if (200 !== $r->statusCode()) {
       throw new IllegalStateException('Cannot get access token (#'.$r->statusCode().'): '.$body);
     }

--- a/src/test/php/web/auth/unittest/FlowTest.class.php
+++ b/src/test/php/web/auth/unittest/FlowTest.class.php
@@ -46,7 +46,7 @@ abstract class FlowTest {
    */
   protected function redirectTo($res) {
     $bytes= $res->output()->bytes();
-    if (preg_match('/<meta http-equiv="refresh" content="1; URL=([^"]+)">/', $bytes, $m)) {
+    if (preg_match('/<meta http-equiv="refresh" content="[0-9]+; URL=([^"]+)">/', $bytes, $m)) {
       return $m[1];
     }
     throw new AssertionFailedError('No redirect URL in response `'.$bytes.'`');

--- a/src/test/php/web/auth/unittest/OAuth1FlowTest.class.php
+++ b/src/test/php/web/auth/unittest/OAuth1FlowTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace web\auth\unittest;
 
 use lang\IllegalStateException;
-use unittest\Assert;
-use unittest\{Expect, Test, TestCase};
+use unittest\{Assert, Expect, Test, TestCase};
+use util\URI;
 use web\auth\oauth\{OAuth1Flow, Client};
 use web\io\{TestInput, TestOutput};
 use web\session\ForTesting;
@@ -18,6 +18,11 @@ class OAuth1FlowTest extends FlowTest {
   #[Test]
   public function can_create() {
     new OAuth1Flow(self::AUTH, [self::ID, self::SECRET], self::CALLBACK);
+  }
+
+  #[Test]
+  public function callback() {
+    Assert::equals(new URI(self::CALLBACK), (new OAuth1Flow(self::AUTH, [self::ID, self::SECRET], self::CALLBACK))->callback());
   }
 
   #[Test, Values('paths')]

--- a/src/test/php/web/auth/unittest/OAuth1FlowTest.class.php
+++ b/src/test/php/web/auth/unittest/OAuth1FlowTest.class.php
@@ -86,6 +86,34 @@ class OAuth1FlowTest extends FlowTest {
     Assert::instance(Client::class, $fixture->authenticate($req, $res, $session));
   }
 
+  #[Test, Values('fragments')]
+  public function appends_fragment($fragment) {
+    $fixture= new OAuth1Flow(self::AUTH, [self::ID, self::SECRET], self::CALLBACK);
+
+    $req= new Request(new TestInput('GET', '/?'.OAuth1Flow::FRAGMENT.'='.urlencode($fragment)));
+    $res= new Response(new TestOutput());
+    $session= (new ForTesting())->create();
+    $session->register(OAuth1Flow::SESSION_KEY, ['target' => 'http://localhost/']);
+
+    $fixture->authenticate($req, $res, $session);
+
+    Assert::equals('http://localhost/#'.$fragment, $session->value(OAuth1Flow::SESSION_KEY)['target']);
+  }
+
+  #[Test, Values('fragments')]
+  public function replaces_fragment($fragment) {
+    $fixture= new OAuth1Flow(self::AUTH, [self::ID, self::SECRET], self::CALLBACK);
+
+    $req= new Request(new TestInput('GET', '/?'.OAuth1Flow::FRAGMENT.'='.urlencode($fragment)));
+    $res= new Response(new TestOutput());
+    $session= (new ForTesting())->create();
+    $session->register(OAuth1Flow::SESSION_KEY, ['target' => 'http://localhost/#original']);
+
+    $fixture->authenticate($req, $res, $session);
+
+    Assert::equals('http://localhost/#'.$fragment, $session->value(OAuth1Flow::SESSION_KEY)['target']);
+  }
+
   /** @deprecated */
   #[Test, Values('paths')]
   public function deprecated_usage_without_callback_uri($path) {

--- a/src/test/php/web/auth/unittest/OAuth1FlowTest.class.php
+++ b/src/test/php/web/auth/unittest/OAuth1FlowTest.class.php
@@ -9,60 +9,66 @@ use web\session\ForTesting;
 use web\{Request, Response};
 
 class OAuth1FlowTest extends FlowTest {
-  const AUTH    = 'https://example.com/oauth';
-  const ID      = 'bf396750';
-  const SECRET  = '5ebe2294ecd0e0f08eab7690d2a6ee69';
+  const AUTH     = 'https://example.com/oauth';
+  const ID       = 'bf396750';
+  const SECRET   = '5ebe2294ecd0e0f08eab7690d2a6ee69';
+  const SERVICE  = 'https://service.example.com';
+  const CALLBACK = 'https://service.example.com/callback';
 
   #[Test]
   public function can_create() {
-    new OAuth1Flow(self::AUTH, [self::ID, self::SECRET]);
+    new OAuth1Flow(self::AUTH, [self::ID, self::SECRET], self::CALLBACK);
   }
 
   #[Test, Values('paths')]
   public function fetches_request_token_then_redirects_to_auth($path) {
     $request= ['oauth_token' => 'T'];
-    $fixture= newinstance(OAuth1Flow::class, [self::AUTH, [self::ID, self::SECRET]], [
+    $fixture= newinstance(OAuth1Flow::class, [self::AUTH, [self::ID, self::SECRET], self::CALLBACK], [
       'request' => function($path, $token= null, $params= []) use($request) { return $request; }
     ]);
+    $session= (new ForTesting())->create();
 
     Assert::equals(
-      sprintf('%s/authenticate?oauth_token=T&oauth_callback=%s', self::AUTH, urlencode('http://localhost'.$path)),
-      $this->redirectTo($this->authenticate($fixture, $path))
+      sprintf('%s/authenticate?oauth_token=T&oauth_callback=%s', self::AUTH, urlencode(self::CALLBACK)),
+      $this->redirectTo($this->authenticate($fixture, $path, $session))
     );
+    Assert::equals('http://localhost'.$path, $session->value(OAuth1Flow::SESSION_KEY)['target']);
   }
 
   #[Test, Values('fragments')]
   public function fetches_request_token_then_redirects_to_auth_with_fragment_in_special_parameter($fragment) {
     $request= ['oauth_token' => 'T'];
-    $fixture= newinstance(OAuth1Flow::class, [self::AUTH, [self::ID, self::SECRET]], [
+    $fixture= newinstance(OAuth1Flow::class, [self::AUTH, [self::ID, self::SECRET], self::CALLBACK], [
       'request' => function($path, $token= null, $params= []) use($request) { return $request; }
     ]);
+    $session= (new ForTesting())->create();
 
     Assert::equals(
-      sprintf('%s/authenticate?oauth_token=T&oauth_callback=%s', self::AUTH, urlencode('http://localhost/?_='.urlencode($fragment))),
-      $this->redirectTo($this->authenticate($fixture, '/#'.$fragment))
+      sprintf('%s/authenticate?oauth_token=T&oauth_callback=%s', self::AUTH, urlencode(self::CALLBACK)),
+      $this->redirectTo($this->authenticate($fixture, '/#'.$fragment, $session))
     );
+    Assert::equals('http://localhost/#'.$fragment, $session->value(OAuth1Flow::SESSION_KEY)['target']);
   }
 
   #[Test]
   public function exchanges_request_token_for_access_token() {
     $access= ['oauth_token' => 'ACCESS-TOKEN', 'oauth_token_secret' => 'XYZ', 'access' => true];
-    $fixture= newinstance(OAuth1Flow::class, [self::AUTH, [self::ID, self::SECRET]], [
+    $fixture= newinstance(OAuth1Flow::class, [self::AUTH, [self::ID, self::SECRET], self::CALLBACK], [
       'request' => function($path, $token= null, $params= []) use($access) { return $access; }
     ]);
     $session= (new ForTesting())->create();
-    $session->register(OAuth1Flow::SESSION_KEY, ['oauth_token' => 'REQUEST-TOKEN']);
+    $session->register(OAuth1Flow::SESSION_KEY, ['oauth_token' => 'REQUEST-TOKEN', 'target' => self::SERVICE]);
 
     $res= $this->authenticate($fixture, '/?oauth_token=REQUEST-TOKEN&oauth_verifier=ABC', $session);
-    Assert::equals('http://localhost/', $res->headers()['Location']);
+    Assert::equals(self::SERVICE, $res->headers()['Location']);
     Assert::equals($access, $session->value(OAuth1Flow::SESSION_KEY));
   }
 
   #[Test, Expect(IllegalStateException::class)]
   public function raises_exception_on_state_mismatch() {
-    $fixture= new OAuth1Flow(self::AUTH, [self::ID, self::SECRET]);
+    $fixture= new OAuth1Flow(self::AUTH, [self::ID, self::SECRET], self::CALLBACK);
     $session= (new ForTesting())->create();
-    $session->register(OAuth1Flow::SESSION_KEY, ['oauth_token' => 'REQUEST-TOKEN']);
+    $session->register(OAuth1Flow::SESSION_KEY, ['oauth_token' => 'REQUEST-TOKEN', 'target' => self::SERVICE]);
 
     $this->authenticate($fixture, '/?oauth_token=MISMATCHED-TOKEN&oauth_verifier=ABC', $session);
   }
@@ -70,7 +76,7 @@ class OAuth1FlowTest extends FlowTest {
   #[Test]
   public function returns_client() {
     $access= ['oauth_token' => 'ACCESS-TOKEN', 'oauth_token_secret' => 'XYZ', 'access' => true];
-    $fixture= new OAuth1Flow(self::AUTH, [self::ID, self::SECRET]);
+    $fixture= new OAuth1Flow(self::AUTH, [self::ID, self::SECRET], self::CALLBACK);
 
     $req= new Request(new TestInput('GET', '/'));
     $res= new Response(new TestOutput());
@@ -78,5 +84,21 @@ class OAuth1FlowTest extends FlowTest {
     $session->register(OAuth1Flow::SESSION_KEY, $access);
 
     Assert::instance(Client::class, $fixture->authenticate($req, $res, $session));
+  }
+
+  /** @deprecated */
+  #[Test, Values('paths')]
+  public function deprecated_usage_without_callback_uri($path) {
+    $request= ['oauth_token' => 'T'];
+    $fixture= newinstance(OAuth1Flow::class, [self::AUTH, [self::ID, self::SECRET]], [
+      'request' => function($path, $token= null, $params= []) use($request) { return $request; }
+    ]);
+    \xp::gc();
+    $session= (new ForTesting())->create();
+
+    Assert::equals(
+      sprintf('%s/authenticate?oauth_token=T&oauth_callback=%s', self::AUTH, urlencode('http://localhost'.$path)),
+      $this->redirectTo($this->authenticate($fixture, $path, $session))
+    );
   }
 }

--- a/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
+++ b/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
@@ -158,7 +158,7 @@ class OAuth2FlowTest extends FlowTest {
   #[Test]
   public function gets_access_token_and_redirects_to_self() {
     $token= ['access_token' => '<TOKEN>', 'token_type' => 'Bearer'];
-    $state= 'SHARED_STATE';
+    $state= 'SHAREDSTATE';
     $fixture= newinstance(OAuth2Flow::class, [self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK], [
       'token' => function($payload) use($token) { return $token; }
     ]);
@@ -173,14 +173,14 @@ class OAuth2FlowTest extends FlowTest {
   #[Test, Values('fragments')]
   public function gets_access_token_and_redirects_to_self_with_fragment($fragment) {
     $token= ['access_token' => '<TOKEN>', 'token_type' => 'Bearer'];
-    $state= 'SHARED_STATE';
+    $state= 'SHAREDSTATE';
     $fixture= newinstance(OAuth2Flow::class, [self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK], [
       'token' => function($payload) use($token) { return $token; }
     ]);
     $session= (new ForTesting())->create();
     $session->register(OAuth2Flow::SESSION_KEY, ['state' => $state, 'target' => self::SERVICE]);
 
-    $res= $this->authenticate($fixture, '/?code=SERVER_CODE&state='.$state.urlencode('?_='.urlencode($fragment)), $session);
+    $res= $this->authenticate($fixture, '/?code=SERVER_CODE&state='.$state.OAuth2Flow::FRAGMENT.urlencode($fragment), $session);
     Assert::equals(self::SERVICE.'#'.$fragment, $res->headers()['Location']);
     Assert::equals($token, $session->value(OAuth2Flow::SESSION_KEY));
   }
@@ -189,9 +189,9 @@ class OAuth2FlowTest extends FlowTest {
   public function raises_exception_on_state_mismatch() {
     $fixture= new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK);
     $session= (new ForTesting())->create();
-    $session->register(OAuth2Flow::SESSION_KEY, ['state' => 'CLIENT_STATE', 'target' => self::SERVICE]);
+    $session->register(OAuth2Flow::SESSION_KEY, ['state' => 'CLIENTSTATE', 'target' => self::SERVICE]);
 
-    $this->authenticate($fixture, '/?state=SERVER_STATE&code=SERVER_CODE', $session);
+    $this->authenticate($fixture, '/?state=SERVERSTATE&code=SERVER_CODE', $session);
   }
 
   #[Test]

--- a/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
+++ b/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
@@ -1,10 +1,10 @@
 <?php namespace web\auth\unittest;
 
 use lang\IllegalStateException;
-use unittest\Assert;
-use unittest\{Expect, Test, TestCase, Values};
+use unittest\{Assert, Expect, Test, TestCase, Values};
+use util\URI;
 use web\auth\oauth\{OAuth2Flow, Client};
-use web\auth\{UseRequest, UseURL};
+use web\auth\{UseCallback, UseRequest, UseURL};
 use web\io\{TestInput, TestOutput};
 use web\session\ForTesting;
 use web\{Request, Response};
@@ -14,6 +14,7 @@ class OAuth2FlowTest extends FlowTest {
   const TOKENS   = 'https://example.com/oauth/access_token';
   const CONSUMER = ['bf396750', '5ebe2294ecd0e0f08eab7690d2a6ee69'];
   const SERVICE  = 'https://service.example.com';
+  const CALLBACK = 'https://service.example.com/callback';
 
   /**
    * Asserts a given response redirects to a given OAuth endpoint
@@ -26,85 +27,114 @@ class OAuth2FlowTest extends FlowTest {
    */
   private function assertLoginWith($service, $scope, $res, $session) {
     $url= sprintf(
-      '%s?response_type=code&client_id=%s&scope=%s&state=%s&redirect_uri=%s',
+      '%s?response_type=code&client_id=%s&scope=%s&redirect_uri=%s&state=%s',
       self::AUTH,
       self::CONSUMER[0],
       implode('+', $scope),
-      $session->value(OAuth2Flow::SESSION_KEY),
-      urlencode($service)
+      urlencode($service),
+      $session->value(OAuth2Flow::SESSION_KEY)['state']
     );
     Assert::equals($url, $this->redirectTo($res));
   }
 
   #[Test]
   public function can_create() {
-    new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER);
+    new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK);
   }
 
   #[Test]
-  public function default_scopes() {
-    Assert::equals(['user'], (new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER))->scopes());
+  public function callback() {
+    Assert::equals(new URI(self::CALLBACK), (new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK))->callback());
+  }
+
+  #[Test]
+  public function scopes() {
+    $scopes= ['user', 'profile'];
+    Assert::equals($scopes, (new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK, $scopes))->scopes());
+  }
+
+  #[Test]
+  public function scopes_defaults_to_user() {
+    Assert::equals(['user'], (new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK))->scopes());
   }
 
   #[Test, Values('paths')]
   public function redirects_to_auth($path) {
-    $fixture= new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER);
+    $fixture= new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK);
     $session= (new ForTesting())->create();
 
     $this->assertLoginWith(
-      'http://localhost'.$path,
+      self::CALLBACK,
       $fixture->scopes(),
       $this->authenticate($fixture, $path, $session),
       $session
     );
+    Assert::equals('http://localhost'.$path, $session->value(OAuth2Flow::SESSION_KEY)['target']);
+  }
+
+  #[Test, Values('paths')]
+  public function redirects_to_auth_with_relative_callback($path) {
+    $fixture= new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER, '/callback');
+    $session= (new ForTesting())->create();
+
+    $this->assertLoginWith(
+      'http://localhost/callback',
+      $fixture->scopes(),
+      $this->authenticate($fixture, $path, $session),
+      $session
+    );
+    Assert::equals('http://localhost'.$path, $session->value(OAuth2Flow::SESSION_KEY)['target']);
   }
 
   #[Test, Values('paths')]
   public function redirects_to_auth_using_request($path) {
-    $fixture= new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER);
+    $fixture= new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK);
     $session= (new ForTesting())->create();
 
     $this->assertLoginWith(
-      'http://localhost'.$path,
+      self::CALLBACK,
       $fixture->scopes(),
       $this->authenticate($fixture->target(new UseRequest()), $path, $session),
       $session
     );
+    Assert::equals('http://localhost'.$path, $session->value(OAuth2Flow::SESSION_KEY)['target']);
   }
 
   #[Test, Values('paths')]
   public function redirects_to_auth_using_url($path) {
-    $fixture= new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER);
+    $fixture= new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK);
     $session= (new ForTesting())->create();
 
     $this->assertLoginWith(
-      self::SERVICE.$path,
+      self::CALLBACK,
       $fixture->scopes(),
       $this->authenticate($fixture->target(new UseURL(self::SERVICE)), $path, $session),
       $session
     );
+    Assert::equals(self::SERVICE.$path, $session->value(OAuth2Flow::SESSION_KEY)['target']);
   }
 
   #[Test, Values('fragments')]
-  public function redirects_to_sso_with_fragment_in_special_parameter($fragment) {
-    $fixture= new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER);
+  public function redirects_to_sso_with_fragment($fragment) {
+    $fixture= new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK);
     $session= (new ForTesting())->create();
 
     $this->assertLoginWith(
-      'http://localhost/?_='.urlencode($fragment),
+      self::CALLBACK,
       $fixture->scopes(),
       $this->authenticate($fixture, '/#'.$fragment, $session),
       $session
     );
+    Assert::equals('http://localhost/#'.$fragment, $session->value(OAuth2Flow::SESSION_KEY)['target']);
   }
 
   #[Test, Values([[['user']], [['user', 'openid']]])]
   public function redirects_to_auth_and_passes_scope($scopes) {
-    $fixture= new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER, $scopes);
+    $fixture= new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK, $scopes);
     $session= (new ForTesting())->create();
 
     $this->assertLoginWith(
-      'http://localhost/',
+      self::CALLBACK,
       $scopes,
       $this->authenticate($fixture, '/', $session),
       $session
@@ -113,12 +143,12 @@ class OAuth2FlowTest extends FlowTest {
 
   #[Test]
   public function redirects_to_auth_when_previous_redirect_incomplete() {
-    $fixture= new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER);
+    $fixture= new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK);
     $session= (new ForTesting())->create();
-    $session->register(OAuth2Flow::SESSION_KEY, 'PREVIOUS_STATE');
+    $session->register(OAuth2Flow::SESSION_KEY, ['state' => 'PREVIOUS_STATE', 'target' => self::SERVICE]);
 
     $this->assertLoginWith(
-      'http://localhost/',
+      self::CALLBACK,
       $fixture->scopes(),
       $this->authenticate($fixture, '/', $session),
       $session
@@ -129,14 +159,14 @@ class OAuth2FlowTest extends FlowTest {
   public function gets_access_token_and_redirects_to_self() {
     $token= ['access_token' => '<TOKEN>', 'token_type' => 'Bearer'];
     $state= 'SHARED_STATE';
-    $fixture= newinstance(OAuth2Flow::class, [self::AUTH, self::TOKENS, self::CONSUMER], [
+    $fixture= newinstance(OAuth2Flow::class, [self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK], [
       'token' => function($payload) use($token) { return $token; }
     ]);
     $session= (new ForTesting())->create();
-    $session->register(OAuth2Flow::SESSION_KEY, $state);
+    $session->register(OAuth2Flow::SESSION_KEY, ['state' => $state, 'target' => self::SERVICE]);
 
-    $res= $this->authenticate($fixture, '/?state='.$state.'&code=SERVER_CODE', $session);
-    Assert::equals('http://localhost/', $res->headers()['Location']);
+    $res= $this->authenticate($fixture, '/?code=SERVER_CODE&state='.$state, $session);
+    Assert::equals(self::SERVICE, $res->headers()['Location']);
     Assert::equals($token, $session->value(OAuth2Flow::SESSION_KEY));
   }
 
@@ -144,22 +174,22 @@ class OAuth2FlowTest extends FlowTest {
   public function gets_access_token_and_redirects_to_self_with_fragment($fragment) {
     $token= ['access_token' => '<TOKEN>', 'token_type' => 'Bearer'];
     $state= 'SHARED_STATE';
-    $fixture= newinstance(OAuth2Flow::class, [self::AUTH, self::TOKENS, self::CONSUMER], [
+    $fixture= newinstance(OAuth2Flow::class, [self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK], [
       'token' => function($payload) use($token) { return $token; }
     ]);
     $session= (new ForTesting())->create();
-    $session->register(OAuth2Flow::SESSION_KEY, $state);
+    $session->register(OAuth2Flow::SESSION_KEY, ['state' => $state, 'target' => self::SERVICE]);
 
-    $res= $this->authenticate($fixture, '/?state='.$state.'&code=SERVER_CODE&_='.urlencode($fragment), $session);
-    Assert::equals('http://localhost/#'.$fragment, $res->headers()['Location']);
+    $res= $this->authenticate($fixture, '/?code=SERVER_CODE&state='.$state.urlencode('?_='.urlencode($fragment)), $session);
+    Assert::equals(self::SERVICE.'#'.$fragment, $res->headers()['Location']);
     Assert::equals($token, $session->value(OAuth2Flow::SESSION_KEY));
   }
 
   #[Test, Expect(IllegalStateException::class)]
   public function raises_exception_on_state_mismatch() {
-    $fixture= new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER);
+    $fixture= new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK);
     $session= (new ForTesting())->create();
-    $session->register(OAuth2Flow::SESSION_KEY, 'CLIENT_STATE');
+    $session->register(OAuth2Flow::SESSION_KEY, ['state' => 'CLIENT_STATE', 'target' => self::SERVICE]);
 
     $this->authenticate($fixture, '/?state=SERVER_STATE&code=SERVER_CODE', $session);
   }
@@ -167,7 +197,7 @@ class OAuth2FlowTest extends FlowTest {
   #[Test]
   public function returns_client_in_final_step() {
     $token= ['access_token' => '<TOKEN>', 'token_type' => 'Bearer'];
-    $fixture= new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER);
+    $fixture= new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK);
 
     $req= new Request(new TestInput('GET', '/'));
     $res= new Response(new TestOutput());
@@ -175,5 +205,35 @@ class OAuth2FlowTest extends FlowTest {
     $session->register(OAuth2Flow::SESSION_KEY, $token);
 
     Assert::instance(Client::class, $fixture->authenticate($req, $res, $session));
+  }
+
+  /** @deprecated */
+  #[Test, Values('paths')]
+  public function deprecated_usage_without_callback_uri($path) {
+    $fixture= new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER);
+    \xp::gc();
+
+    $session= (new ForTesting())->create();
+    $this->assertLoginWith(
+      'http://localhost'.$path,
+      $fixture->scopes(),
+      $this->authenticate($fixture, $path, $session),
+      $session
+    );
+  }
+
+  /** @deprecated */
+  #[Test, Values('paths')]
+  public function deprecated_usage_with_scopes_in_place_of_callback_uri($path) {
+    $fixture= new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER, ['user']);
+    \xp::gc();
+
+    $session= (new ForTesting())->create();
+    $this->assertLoginWith(
+      'http://localhost'.$path,
+      $fixture->scopes(),
+      $this->authenticate($fixture, $path, $session),
+      $session
+    );
   }
 }


### PR DESCRIPTION
This pull request changes the OAuth implementations to pass paths, parameters and URL fragments behind the scenes. See https://github.com/xp-forge/web-auth/issues/5#issuecomment-751356752:

> If a client wishes to include request-specific data in the redirect URL, it can instead use the “state” parameter to store data that will be included after the user is redirected. It can either encode the data in the state parameter itself, or use the state parameter as a session ID to store the state on the server.

* [x] OAuth2
* [x] OAuth1 (*also includes fix for URLs including fragments!*)