### PR TITLE
Add support for using user objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
+        extensions: bcmath
         ini-values: date.timezone=Europe/Berlin
 
     - name: Setup Problem Matchers for PHP

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "xp-forge/web": "^2.0 | ^1.0",
     "xp-forge/json": "^4.0 | ^3.1",
     "xp-forge/sessions": "^2.0 | ^1.0",
+    "xp-forge/marshalling": "^1.0",
     "php": ">=7.0.0"
   },
   "require-dev" : {

--- a/src/main/php/web/auth/SessionBased.class.php
+++ b/src/main/php/web/auth/SessionBased.class.php
@@ -1,9 +1,11 @@
 <?php namespace web\auth;
 
+use util\data\Marshalling;
 use web\session\Sessions;
 
 class SessionBased extends Authentication {
   private $flow, $sessions, $lookup;
+  private $marshalling= null;
 
   /**
    * Creates a login instance
@@ -29,6 +31,34 @@ class SessionBased extends Authentication {
   }
 
   /**
+   * Unmarshals a value after reading it from the session
+   *
+   * @param  var $value
+   * @return var
+   */
+  protected function unmarshal($value) {
+    if (is_array($value) && isset($value['__type'])) {
+      if (null === $this->marshalling) $this->marshalling= new Marshalling();
+      return $this->marshalling->unmarshal($value, $value['__type']);
+    }
+    return $value;
+  }
+
+  /**
+   * Marshals a value for storing in the session
+   *
+   * @param  var $value
+   * @return var
+   */
+  protected function marshal($value) {
+    if (is_object($value)) {
+      if (null === $this->marshalling) $this->marshalling= new Marshalling();
+      return ['__type' => get_class($value)] + $this->marshalling->marshal($value);
+    }
+    return $value;
+  }
+
+  /**
    * Executes authentication flow. On success, the user is looked up and
    * registered in the session under a key "user".
    *
@@ -39,7 +69,7 @@ class SessionBased extends Authentication {
    */
   public function filter($req, $res, $invocation) {
     if ($session= $this->sessions->locate($req)) {
-      $user= $session->value('user');
+      $user= $this->unmarshal($session->value('user'));
     } else {
       $session= $this->sessions->create();
       $user= null;
@@ -50,7 +80,7 @@ class SessionBased extends Authentication {
 
       // Optionally map result to a user using lookup, otherwise use result directly
       $user= $this->lookup ? ($this->lookup)($result) : $result;
-      $session->register('user', $user);
+      $session->register('user', $this->marshal($user));
     }
 
     try {

--- a/src/test/php/web/auth/unittest/SessionBasedTest.class.php
+++ b/src/test/php/web/auth/unittest/SessionBasedTest.class.php
@@ -109,6 +109,29 @@ class SessionBasedTest {
   }
 
   #[Test]
+  public function marshals_user_to_session() {
+    $session= $this->sessions->create();
+
+    $auth= new SessionBased($this->authenticate(new User(1, 'test')), $this->sessions);
+    $this->handle(['Cookie' => 'session='.$session->id()], $auth->required(function($req, $res) { }));
+
+    Assert::equals(['__type' => User::class, 'id' => 1, 'username' => 'test'], $session->value('user'));
+  }
+
+  #[Test]
+  public function unmarshals_user_from_session() {
+    $session= $this->sessions->create();
+    $session->register('user', ['__type' => User::class, 'id' => 1, 'username' => 'test']);
+
+    $auth= new SessionBased($this->authenticate(null), $this->sessions);
+    $this->handle(['Cookie' => 'session='.$session->id()], $auth->required(function($req, $res) use(&$user) {
+      $user= $req->value('user');
+    }));
+
+    Assert::equals(new User(1, 'test'), $user);
+  }
+
+  #[Test]
   public function session_is_attached_after_authentication() {
     $user= ['username' => 'test'];
     $attached= null;

--- a/src/test/php/web/auth/unittest/User.class.php
+++ b/src/test/php/web/auth/unittest/User.class.php
@@ -1,0 +1,22 @@
+<?php namespace web\auth\unittest;
+
+class User {
+  private $id, $username;
+
+  /**
+   * Creates a new user
+   *
+   * @param  int $id
+   * @param  string $username
+   */
+  public function __construct($id, $username) {
+    $this->id= $id;
+    $this->username= $username;
+  }
+
+  /** @return int */
+  public function id() { return $this->id; }
+
+  /** @return string */
+  public function username() { return $this->username; }
+}


### PR DESCRIPTION
If a user lookup method returns an object, this may not be correctly passed to the request depending on the session implementation used.