### PR TITLE
Create random token, store in session and pass to request

### DIFF
--- a/src/test/php/web/auth/unittest/SessionBasedTest.class.php
+++ b/src/test/php/web/auth/unittest/SessionBasedTest.class.php
@@ -109,6 +109,16 @@ class SessionBasedTest {
   }
 
   #[Test]
+  public function passes_token() {
+    $auth= new SessionBased($this->authenticate(['username' => 'test']), $this->sessions);
+    $this->handle([], $auth->required(function($req, $res) use(&$token) {
+      $token= $req->value('token');
+    }));
+
+    Assert::equals(SessionBased::TOKEN_LENGTH, strlen(base64_decode($token)));
+  }
+
+  #[Test]
   public function session_is_attached_after_authentication() {
     $user= ['username' => 'test'];
     $attached= null;


### PR DESCRIPTION
This token should be uses in login forms to prevent CSRF attacks.

## Why this is important

> Without CSRF protection, a malicious website could create an HTML form that points to your application's /user/email route and submits the malicious user's own email address:
> 
> ```html
> <form action="https://your-application.com/user/email" method="POST">
>   <input type="email" value="malicious-email@example.com">
> </form>
>
> <script>document.forms[0].submit();</script>
> ```
>
> If the malicious website automatically submits the form when the page is loaded, the malicious user only needs to lure an unsuspecting user of your application to visit their website and their email address will be changed in your application.

*Source: https://laravel.com/docs/8.x/csrf*

## Insecure forms will break ⚠

When this is released, all forms not using the CSRF token (*except those with `GET` method, like search functions*) in an application using authentication will fail with a `400 Bad Request` error. 

![image](https://user-images.githubusercontent.com/696742/118288212-77beee00-b4d4-11eb-9cf3-35022b372f2c.png)

To mitigate, they need now definitely to include a hidden field as follows:

```html
<input type="hidden" name="token" value="{{request.values.token}}">
```

**Because of this break, this will be released as a major version!**

## Further reading

See https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.md