### PR TITLE
Store "id_token" if returned from OAuth token endpoint

### DIFF
--- a/src/main/php/web/auth/oauth/ByAccessToken.class.php
+++ b/src/main/php/web/auth/oauth/ByAccessToken.class.php
@@ -8,18 +8,20 @@ class ByAccessToken extends Client {
   /**
    * Creates a new instance with a given token and type (defaulting to 'Bearer')
    *
-   * @param  string|util.Secret $token
+   * @param  string|util.Secret $token `access_token`
    * @param  string $type
    * @param  ?string $scope
    * @param  ?int $expires
-   * @param  ?string|util.Secret $refresh
+   * @param  ?string|util.Secret $refresh `refresh_token`
+   * @param  ?string|util.Secret $id `id_token`
    */
-  public function __construct($token, $type= 'Bearer', $scope= null, $expires= null, $refresh= null) {
+  public function __construct($token, $type= 'Bearer', $scope= null, $expires= null, $refresh= null, $id= null) {
     $this->token= $token instanceof Secret ? $token : new Secret($token);
     $this->type= $type;
     $this->scope= $scope;
-    $this->expires= $expires;
-    $this->refresh= $refresh instanceof Secret ? $refresh : new Secret($refresh);
+    $this->expires= null === $expires ? null : (int)$expires;
+    $this->refresh= null === $refresh ? null : ($refresh instanceof Secret ? $refresh : new Secret($refresh));
+    $this->id= null === $id ? null : ($id instanceof Secret ? $id : new Secret($id));
   }
 
   /** @return util.Secret */
@@ -36,6 +38,9 @@ class ByAccessToken extends Client {
 
   /** @return ?util.Secret */
   public function refresh() { return $this->refresh; }
+
+  /** @return ?util.Secret */
+  public function id() { return $this->id; }
 
   /**
    * Authorize request and returns it

--- a/src/main/php/web/auth/oauth/OAuth2Flow.class.php
+++ b/src/main/php/web/auth/oauth/OAuth2Flow.class.php
@@ -94,7 +94,8 @@ class OAuth2Flow extends Flow {
         $stored['token_type'] ?? 'Bearer',
         $stored['scope'] ?? null,
         $stored['expires_in'] ?? null,
-        $stored['refresh_token'] ?? null
+        $stored['refresh_token'] ?? null,
+        $stored['id_token'] ?? null
       );
     }
 

--- a/src/test/php/web/auth/unittest/OAuthByAccessTokenTest.class.php
+++ b/src/test/php/web/auth/unittest/OAuthByAccessTokenTest.class.php
@@ -6,11 +6,13 @@ use unittest\{Assert, Test};
 use web\auth\oauth\ByAccessToken;
 
 class OAuthByAccessTokenTest {
-  const TOKEN = '073204f68de382213e92c5792b07b33b';
+  const TOKEN   = '073204f68de382213e92c5792b07b33b';
+  const REFRESH = '0.ARAAVA2S7uRGHk6qw_dU-sy2k0tYTL';
+  const ID      = 'eyJ0eXJ9.eyJhdWQiOiJJ9.EHgx6iY0P';
 
   /** Returns a fixture which records HTTP requests instead of actually sending them */
   private function newFixture() {
-    return new class(self::TOKEN, 'Bearer') extends ByAccessToken {
+    return new class(self::TOKEN, 'Bearer', 'profile', 3599, self::REFRESH, self::ID) extends ByAccessToken {
       public $requests= [];
 
       /** Overriden from base class */
@@ -28,17 +30,57 @@ class OAuthByAccessTokenTest {
 
   #[Test]
   public function token() {
-    Assert::equals(self::TOKEN, (new ByAccessToken(self::TOKEN, 'Bearer'))->token()->reveal());
+    Assert::equals(self::TOKEN, $this->newFixture()->token()->reveal());
   }
 
   #[Test]
   public function type() {
-    Assert::equals('Bearer', (new ByAccessToken(self::TOKEN, 'Bearer'))->type());
+    Assert::equals('Bearer', $this->newFixture()->type());
+  }
+
+  #[Test]
+  public function scope() {
+    Assert::equals('profile', $this->newFixture()->scope());
+  }
+
+  #[Test]
+  public function expires() {
+    Assert::equals(3599, $this->newFixture()->expires());
+  }
+
+  #[Test]
+  public function refresh() {
+    Assert::equals(self::REFRESH, $this->newFixture()->refresh()->reveal());
+  }
+
+  #[Test]
+  public function id() {
+    Assert::equals(self::ID, $this->newFixture()->id()->reveal());
   }
 
   #[Test]
   public function type_defaults_to_bearer() {
     Assert::equals('Bearer', (new ByAccessToken(self::TOKEN))->type());
+  }
+
+  #[Test]
+  public function scope_defaults_to_null() {
+    Assert::null((new ByAccessToken(self::TOKEN))->scope());
+  }
+
+  #[Test]
+  public function expires_defaults_to_null() {
+    Assert::null((new ByAccessToken(self::TOKEN))->expires());
+  }
+
+  #[Test]
+  public function refresh_defaults_to_null() {
+    Assert::null((new ByAccessToken(self::TOKEN))->refresh());
+  }
+
+  #[Test]
+  public function id_defaults_to_null() {
+    Assert::null((new ByAccessToken(self::TOKEN))->id());
   }
 
   #[Test]


### PR DESCRIPTION
This pull request adds an `id()` method to fetch an *id_token* from an OAuth response should it be available.

* * *

Quoting https://www.oauth.com/oauth2-servers/signing-in-with-google/getting-an-id-token/:

> Google will verify our request, and then respond with both an access token as well as an ID token. The response will look like the below.

```json
{
  "access_token": "ya29.Glins-oLtuljNVfthQU2bpJVJPTu",
  "token_type": "Bearer",
  "expires_in": 3600,
  "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6ImFmZmM2MjkwN[...]Cg"
}
```

