### PR TITLE
Ensure session is only attached once

### DIFF
--- a/src/main/php/web/auth/SessionBased.class.php
+++ b/src/main/php/web/auth/SessionBased.class.php
@@ -57,7 +57,13 @@ class SessionBased extends Authentication {
     }
 
     if (null === $user) {
-      if (null === ($result= $this->flow->authenticate($req, $res, $session))) return;
+
+      // Authentication may require redirection in order to fulfill its job.
+      // In this case, return early from this method w/o passing control on.
+      if (null === ($result= $this->flow->authenticate($req, $res, $session))) {
+        $session->transmit($res);
+        return;
+      }
 
       // Optionally map result to a user using lookup, otherwise use result directly
       $user= $this->lookup ? ($this->lookup)($result) : $result;

--- a/src/main/php/web/auth/cas/CasFlow.class.php
+++ b/src/main/php/web/auth/cas/CasFlow.class.php
@@ -98,7 +98,6 @@ class CasFlow extends Flow {
     }
 
     $session->register(self::SESSION_KEY, $user);
-    $session->transmit($response);
     $this->finalize($response, $service);
   }
 }

--- a/src/main/php/web/auth/oauth/OAuth1Flow.class.php
+++ b/src/main/php/web/auth/oauth/OAuth1Flow.class.php
@@ -77,8 +77,6 @@ class OAuth1Flow extends Flow {
     // We have an access token, reset state and return an authenticated session
     if (isset($state['access'])) {
       $session->remove(self::SESSION_KEY);
-      $session->transmit($response);
-
       return new BySignedRequests($this->signature->with(new Token($state['oauth_token'], $state['oauth_token_secret'])));
     }
 
@@ -91,7 +89,6 @@ class OAuth1Flow extends Flow {
       }
 
       $session->register(self::SESSION_KEY, $state);
-      $session->transmit($response);
       $response->send('document.location.replace(target)', 'text/javascript');
       return null;
     }
@@ -104,7 +101,6 @@ class OAuth1Flow extends Flow {
     if (null === $state || null === $server) {
       $token= $this->request('/request_token', null, ['oauth_callback' => $callback]);
       $session->register(self::SESSION_KEY, $token + ['target' => (string)$uri]);
-      $session->transmit($response);
 
       // Redirect the user to the authorization page
       $target= sprintf(
@@ -137,7 +133,6 @@ class OAuth1Flow extends Flow {
       // Back from authentication redirect, upgrade request token to access token
       $access= $this->request('/access_token', $state['oauth_token'], ['oauth_verifier' => $request->param('oauth_verifier')]);
       $session->register(self::SESSION_KEY, $access + ['access' => true]);
-      $session->transmit($response);
 
       // Redirect to self
       $this->finalize($response, $state['target']);

--- a/src/main/php/web/auth/oauth/OAuth2Flow.class.php
+++ b/src/main/php/web/auth/oauth/OAuth2Flow.class.php
@@ -87,8 +87,6 @@ class OAuth2Flow extends Flow {
     // and https://tools.ietf.org/html/rfc6749#section-5.1
     if (isset($stored['access_token'])) {
       $session->remove(self::SESSION_KEY);
-      $session->transmit($response);
-
       return new ByAccessToken(
         $stored['access_token'],
         $stored['token_type'] ?? 'Bearer',
@@ -107,7 +105,6 @@ class OAuth2Flow extends Flow {
     if (null === $stored || null === $server) {
       $state= bin2hex($this->rand->bytes(16));
       $session->register(self::SESSION_KEY, ['state' => $state, 'target' => (string)$uri]);
-      $session->transmit($response);
 
       // Redirect the user to the authorization page
       $params= [
@@ -150,7 +147,6 @@ class OAuth2Flow extends Flow {
         'state'         => $stored['state']
       ]);
       $session->register(self::SESSION_KEY, $token);
-      $session->transmit($response);
 
       // Redirect to self, using encoded fragment if present
       $this->finalize($response, $stored['target'].(isset($state[1]) ? '#'.urldecode($state[1]) : ''));

--- a/src/test/php/web/auth/unittest/SessionBasedTest.class.php
+++ b/src/test/php/web/auth/unittest/SessionBasedTest.class.php
@@ -4,7 +4,7 @@ use lang\IllegalStateException;
 use unittest\Assert;
 use web\auth\{SessionBased, Flow};
 use web\io\{TestInput, TestOutput};
-use web\session\{ForTesting, Transport};
+use web\session\{ISession, ForTesting, Transport};
 use web\{Request, Response};
 
 class SessionBasedTest {
@@ -119,18 +119,38 @@ class SessionBasedTest {
   }
 
   #[Test]
+  public function session_is_attached_when_redirecting() {
+    $auth= new SessionBased($this->authenticate(null), $this->sessions->via(newinstance(Transport::class, [], [
+      'locate' => function($sessions, $request) { return null; },
+      'detach' => function($sessions, $response, $session) { },
+      'attach' => function($sessions, $response, $session) use(&$attached) {
+        $attached= $session;
+        $attached->register('times', $attached->value('times', 0) + 1);
+      },
+    ])));
+    $this->handle([], $auth->required(function($req, $res) { }));
+
+    Assert::instance(ISession::class, $attached);
+    Assert::equals(1, $attached->value('times'));
+  }
+
+  #[Test]
   public function session_is_attached_after_authentication() {
     $user= ['username' => 'test'];
     $attached= null;
 
     $auth= new SessionBased($this->authenticate($user), $this->sessions->via(newinstance(Transport::class, [], [
       'locate' => function($sessions, $request) { return null; },
-      'attach' => function($sessions, $response, $session) use(&$attached) { $attached= $session; },
-      'detach' => function($sessions, $response, $session) { }
+      'detach' => function($sessions, $response, $session) { },
+      'attach' => function($sessions, $response, $session) use(&$attached) {
+        $attached= $session;
+        $attached->register('times', $attached->value('times', 0) + 1);
+      },
     ])));
     $this->handle([], $auth->required(function($req, $res) { }));
 
-    Assert::notEquals(null, $attached);
+    Assert::instance(ISession::class, $attached);
+    Assert::equals(1, $attached->value('times'));
     Assert::equals($user, $attached->value('user'));
   }
 }


### PR DESCRIPTION
In the previous implementation, *Flow* implementations were responsible for attaching sessions to the response. This lead to cases when the `attach()` method was called twice. Typically not a problem, this is unnecessary overhead at least.