### PR TITLE
Allow login flows to return Continuation instances

### DIFF
--- a/src/main/php/web/auth/Continuation.class.php
+++ b/src/main/php/web/auth/Continuation.class.php
@@ -1,0 +1,16 @@
+<?php namespace web\auth;
+
+class Continuation {
+  public $uri, $value;
+
+  /**
+   * Creates a new continuation
+   *
+   * @param  string $uri
+   * @param  var $value
+   */
+  public function __construct($uri, $value= null) {
+    $this->uri= $uri;
+    $this->value= $value;
+  }
+}

--- a/src/test/php/web/auth/unittest/SessionBasedTest.class.php
+++ b/src/test/php/web/auth/unittest/SessionBasedTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\IllegalStateException;
 use unittest\Assert;
-use web\auth\{SessionBased, Flow};
+use web\auth\{Continuation, SessionBased, Flow};
 use web\io\{TestInput, TestOutput};
 use web\session\{ISession, ForTesting};
 use web\{Request, Response};
@@ -154,5 +154,16 @@ class SessionBasedTest {
     Assert::instance(ISession::class, $attached);
     Assert::equals(1, $attached->value('times'));
     Assert::equals($user, $attached->value('auth')[1]);
+  }
+
+  #[Test]
+  public function continuation_rewrites_uri_and_passes_value() {
+    $sessions= new ForTesting();
+    $auth= new SessionBased($this->authenticate(new Continuation('/login', 'test')), $sessions);
+    $this->handle([], $auth->required(function($req, $res) use(&$passed) {
+      $passed= [$req->uri()->path(), $req->value('auth')];
+    }));
+
+    Assert::equals(['/login', 'test'], $passed);
   }
 }


### PR DESCRIPTION
These will rewrite the request URI and pass an "auth" value with the response, and then continue processing the request. This can be used e.g. to show a login page.