### PR TITLE
Reuse state when previous redirect was incomplete

### DIFF
--- a/src/main/php/web/auth/oauth/OAuth2Flow.class.php
+++ b/src/main/php/web/auth/oauth/OAuth2Flow.class.php
@@ -130,9 +130,15 @@ class OAuth2Flow extends Flow {
     // Start authorization flow to acquire an access token
     $server= $request->param('state');
     if (null === $stored || null === $server) {
-      $state= bin2hex($this->rand->bytes(16));
-      $session->register(self::SESSION_KEY, ['state' => $state, 'target' => (string)$uri]);
-      $session->transmit($response);
+
+      // Reuse state
+      if (isset($stored['state'])) {
+        $state= $stored['state'];
+      } else {
+        $state= bin2hex($this->rand->bytes(16));
+        $session->register(self::SESSION_KEY, ['state' => $state, 'target' => (string)$uri]);
+        $session->transmit($response);
+      }
 
       // Redirect the user to the authorization page
       $params= [

--- a/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
+++ b/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
@@ -156,6 +156,16 @@ class OAuth2FlowTest extends FlowTest {
   }
 
   #[Test]
+  public function reuses_state_when_previous_redirect_incomplete() {
+    $fixture= new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK);
+    $session= (new ForTesting())->create();
+    $session->register(OAuth2Flow::SESSION_KEY, ['state' => 'REUSED_STATE', 'target' => self::SERVICE]);
+
+    $this->authenticate($fixture, '/', $session);
+    Assert::equals('REUSED_STATE', $session->value(OAuth2Flow::SESSION_KEY)['state']);
+  }
+
+  #[Test]
   public function gets_access_token_and_redirects_to_self() {
     $token= ['access_token' => '<TOKEN>', 'token_type' => 'Bearer'];
     $state= 'SHAREDSTATE';


### PR DESCRIPTION
See #19 - tests verify this as OK but needs some real-life exposure before being merged.