### PR TITLE
Implement certificate-based OAuth2 flow

### DIFF
--- a/src/main/php/web/auth/oauth/ByCertificate.class.php
+++ b/src/main/php/web/auth/oauth/ByCertificate.class.php
@@ -1,0 +1,42 @@
+<?php namespace web\auth\oauth;
+
+use lang\IllegalArgumentException;
+use util\UUID;
+
+class ByCertificate extends Credentials {
+  private $fingerprint, $key;
+
+  /**
+   * Creates a new certificate
+   *
+   * @param  string $clientId
+   * @param  string $fingerprint
+   * @param  var $key Anything supported by `openssl_pkey_get_private()`
+   * @throws lang.IllegalArgumentException
+   */
+  public function __construct($clientId, $fingerprint, $key) {
+    parent::__construct($clientId);
+    $this->fingerprint= $fingerprint;
+    if (false === ($this->key= openssl_pkey_get_private($key))) {
+      throw new IllegalArgumentException(openssl_error_string());
+    }
+  }
+
+  public function params(string $endpoint): array {
+    $time= time();
+    $jwt= new JWT(['alg' => 'RS256', 'typ' => 'JWT', 'x5t' => JWT::base64(hex2bin($this->fingerprint))], [
+      'aud' => $endpoint,
+      'exp' => $time + 3600,
+      'iss' => $this->clientId,
+      'jti' => UUID::timeUUID()->hashCode(),
+      'nbf' => $time,
+      'sub' => $this->clientId,
+    ]);
+
+    return [
+      'client_id'             => $this->clientId,
+      'client_assertion'      => $jwt->sign($this->key),
+      'client_assertion_type' => 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+    ];
+  }
+}

--- a/src/main/php/web/auth/oauth/ByCertificate.class.php
+++ b/src/main/php/web/auth/oauth/ByCertificate.class.php
@@ -12,23 +12,23 @@ use util\UUID;
  * @ext  openssl
  */
 class ByCertificate extends Credentials {
-  private $fingerprint, $key, $validity;
+  private $fingerprint, $privateKey, $validity;
 
   /**
    * Creates a new certificate
    *
    * @param  string $clientId
    * @param  string $fingerprint
-   * @param  var $key Anything supported by `openssl_pkey_get_private()`
+   * @param  var $privateKey Anything supported by `openssl_pkey_get_private()`
    * @param  int $validity
    * @throws lang.IllegalArgumentException
    */
-  public function __construct($clientId, $fingerprint, $key, $validity= 3600) {
+  public function __construct($clientId, $fingerprint, $privateKey, $validity= 3600) {
     parent::__construct($clientId);
     $this->fingerprint= str_replace(':', '', $fingerprint);
     $this->validity= $validity;
 
-    if (false === ($this->key= openssl_pkey_get_private($key))) {
+    if (false === ($this->privateKey= openssl_pkey_get_private($privateKey))) {
       throw new IllegalArgumentException(openssl_error_string());
     }
   }
@@ -39,15 +39,15 @@ class ByCertificate extends Credentials {
     $jwt= new JWT(['alg' => 'RS256', 'typ' => 'JWT', 'x5t' => JWT::base64(hex2bin($this->fingerprint))], [
       'aud' => $endpoint,
       'exp' => $time + $this->validity,
-      'iss' => $this->clientId,
+      'iss' => $this->key,
       'jti' => UUID::timeUUID()->hashCode(),
       'nbf' => $time,
-      'sub' => $this->clientId,
+      'sub' => $this->key,
     ]);
 
     return [
-      'client_id'             => $this->clientId,
-      'client_assertion'      => $jwt->sign($this->key),
+      'client_id'             => $this->key,
+      'client_assertion'      => $jwt->sign($this->privateKey),
       'client_assertion_type' => 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
     ];
   }

--- a/src/main/php/web/auth/oauth/ByCertificate.class.php
+++ b/src/main/php/web/auth/oauth/ByCertificate.class.php
@@ -8,6 +8,7 @@ use util\UUID;
  * Authorization Grants
  *
  * @test web.auth.unittest.ByCertificateTest
+ * @see  https://tools.ietf.org/html/rfc7523
  * @ext  openssl
  */
 class ByCertificate extends Credentials {

--- a/src/main/php/web/auth/oauth/BySecret.class.php
+++ b/src/main/php/web/auth/oauth/BySecret.class.php
@@ -16,8 +16,8 @@ class BySecret extends Credentials {
     $this->secret= $secret instanceof Secret ? $secret : new Secret($secret);
   }
 
-  /** Returns parameter to be used in authentication process */
-  public function params(string $endpoint): array {
+  /** Returns parameters to be used in authentication process */
+  public function params(string $endpoint, int $time= null): array {
     return [
       'client_id'     => $this->clientId,
       'client_secret' => $this->secret->reveal(),

--- a/src/main/php/web/auth/oauth/BySecret.class.php
+++ b/src/main/php/web/auth/oauth/BySecret.class.php
@@ -1,0 +1,26 @@
+<?php namespace web\auth\oauth;
+
+use util\Secret;
+
+class BySecret extends Credentials {
+  protected $secret;
+
+  /**
+   * Creates credentials with a client ID and secret
+   *
+   * @param  string $clientId
+   * @param  string|util.Secret $secret
+   */
+  public function __construct($clientId, $secret) {
+    parent::__construct($clientId);
+    $this->secret= $secret instanceof Secret ? $secret : new Secret($secret);
+  }
+
+  /** Returns parameter to be used in authentication process */
+  public function params(string $endpoint): array {
+    return [
+      'client_id'     => $this->clientId,
+      'client_secret' => $this->secret->reveal(),
+    ];
+  }
+}

--- a/src/main/php/web/auth/oauth/BySecret.class.php
+++ b/src/main/php/web/auth/oauth/BySecret.class.php
@@ -3,7 +3,7 @@
 use util\Secret;
 
 class BySecret extends Credentials {
-  protected $secret;
+  private $secret;
 
   /**
    * Creates credentials with a client ID and secret
@@ -15,6 +15,9 @@ class BySecret extends Credentials {
     parent::__construct($clientId);
     $this->secret= $secret instanceof Secret ? $secret : new Secret($secret);
   }
+
+  /** @return util.Secret */
+  public function secret() { return $this->secret; }
 
   /** Returns parameters to be used in authentication process */
   public function params(string $endpoint, int $time= null): array {

--- a/src/main/php/web/auth/oauth/BySecret.class.php
+++ b/src/main/php/web/auth/oauth/BySecret.class.php
@@ -22,7 +22,7 @@ class BySecret extends Credentials {
   /** Returns parameters to be used in authentication process */
   public function params(string $endpoint, int $time= null): array {
     return [
-      'client_id'     => $this->clientId,
+      'client_id'     => $this->key,
       'client_secret' => $this->secret->reveal(),
     ];
   }

--- a/src/main/php/web/auth/oauth/Credentials.class.php
+++ b/src/main/php/web/auth/oauth/Credentials.class.php
@@ -13,6 +13,6 @@ abstract class Credentials {
     $this->clientId= $clientId;
   }
 
-  /** Returns parameter to be used in authentication process */
-  public abstract function params(string $endpoint): array;
+  /** Returns parameters to be used in authentication process */
+  public abstract function params(string $endpoint, int $time= null): array;
 }

--- a/src/main/php/web/auth/oauth/Credentials.class.php
+++ b/src/main/php/web/auth/oauth/Credentials.class.php
@@ -1,0 +1,18 @@
+<?php namespace web\auth\oauth;
+
+abstract class Credentials {
+  public $clientId;
+
+  /**
+   * Creates credentials with a client ID and secret
+   *
+   * @param  string $clientId
+   * @param  string|util.Secret $secret
+   */
+  public function __construct($clientId) {
+    $this->clientId= $clientId;
+  }
+
+  /** Returns parameter to be used in authentication process */
+  public abstract function params(string $endpoint): array;
+}

--- a/src/main/php/web/auth/oauth/Credentials.class.php
+++ b/src/main/php/web/auth/oauth/Credentials.class.php
@@ -1,16 +1,16 @@
 <?php namespace web\auth\oauth;
 
 abstract class Credentials {
-  public $clientId;
+  public $key;
 
   /**
    * Creates credentials with a client ID and secret
    *
-   * @param  string $clientId
+   * @param  string $key
    * @param  string|util.Secret $secret
    */
-  public function __construct($clientId) {
-    $this->clientId= $clientId;
+  public function __construct($key) {
+    $this->key= $key;
   }
 
   /** Returns parameters to be used in authentication process */

--- a/src/main/php/web/auth/oauth/JWT.class.php
+++ b/src/main/php/web/auth/oauth/JWT.class.php
@@ -22,14 +22,20 @@ class JWT {
     return strtr(rtrim(base64_encode($bytes), '='), '+/', '-_');
   }
 
-  /** Sign JWT and return token */
+  /**
+   * Sign JWT and return token
+   *
+   * @param  OpenSSLAsymmetricKey $key
+   * @return string
+   * @throws lang.IllegalStateException if signing fails
+   */
   public function sign($key): string {
     $input= self::base64(json_encode($this->header)).'.'.self::base64(json_encode($this->payload));
 
     // Hardcode SHA256 signing via OpenSSL here, would need algorithm-based
     // handling in order for this to be a full implementation, see e.g.
     // https://github.com/firebase/php-jwt/blob/v6.2.0/src/JWT.php#L220
-    if (!openssl_sign($input, $signature, openssl_pkey_get_private($key), 'SHA256')) {
+    if (!openssl_sign($input, $signature, $key, 'SHA256')) {
       throw new IllegalStateException(openssl_error_string());
     }
 

--- a/src/main/php/web/auth/oauth/JWT.class.php
+++ b/src/main/php/web/auth/oauth/JWT.class.php
@@ -1,0 +1,38 @@
+<?php namespace web\auth\oauth;
+
+use lang\IllegalStateException;
+
+/**
+ * Very simple JWT implementation (only supporting `RS256`)
+ *
+ * @see  https://tools.ietf.org/html/rfc7519
+ * @ext  openssl
+ */
+class JWT {
+  private $header, $payload;
+
+  /** Creates a new JWT with a given header and payload */
+  public function __construct(array $header, array $payload) {
+    $this->header= $header;
+    $this->payload= $payload;
+  }
+
+  /** URL-safe Base64 encoding */
+  public static function base64(string $bytes): string {
+    return strtr(rtrim(base64_encode($bytes), '='), '+/', '-_');
+  }
+
+  /** Sign JWT and return token */
+  public function sign($key): string {
+    $input= self::base64(json_encode($this->header)).'.'.self::base64(json_encode($this->payload));
+
+    // Hardcode SHA256 signing via OpenSSL here, would need algorithm-based
+    // handling in order for this to be a full implementation, see e.g.
+    // https://github.com/firebase/php-jwt/blob/v6.2.0/src/JWT.php#L220
+    if (!openssl_sign($input, $signature, openssl_pkey_get_private($key), 'SHA256')) {
+      throw new IllegalStateException(openssl_error_string());
+    }
+
+    return $input.'.'.self::base64($signature);
+  }
+}

--- a/src/main/php/web/auth/oauth/OAuth2Flow.class.php
+++ b/src/main/php/web/auth/oauth/OAuth2Flow.class.php
@@ -17,7 +17,7 @@ class OAuth2Flow extends Flow {
    *
    * @param  string|util.URI $auth
    * @param  string|util.URI $tokens
-   * @param  web.auth.oauth.Credentials|string[]|util.Secret[] $consumer
+   * @param  web.auth.oauth.Credentials|(string|util.Secret)[] $consumer
    * @param  string|util.URI $callback
    * @param  string[] $scopes
    */

--- a/src/main/php/web/auth/oauth/OAuth2Flow.class.php
+++ b/src/main/php/web/auth/oauth/OAuth2Flow.class.php
@@ -17,14 +17,22 @@ class OAuth2Flow extends Flow {
    *
    * @param  string|util.URI $auth
    * @param  string|util.URI $tokens
-   * @param  web.auth.oauth.Token|string[]|util.Secret[] $consumer
+   * @param  web.auth.oauth.Credentials|string[]|util.Secret[] $consumer
    * @param  string|util.URI $callback
    * @param  string[] $scopes
    */
   public function __construct($auth, $tokens, $consumer, $callback= null, $scopes= ['user']) {
     $this->auth= $auth instanceof URI ? $auth : new URI($auth);
     $this->tokens= $tokens instanceof URI ? $tokens : new URI($tokens);
-    $this->consumer= $consumer instanceof Token ? $consumer : new Token(...$consumer);
+
+    // BC: Support web.auth.oauth.Token instances
+    if ($consumer instanceof Credentials) {
+      $this->consumer= $consumer;
+    } else if ($consumer instanceof Token) {
+      $this->consumer= new BySecret($consumer->key()->reveal(), $consumer->secret());
+    } else {
+      $this->consumer= new BySecret(...$consumer);
+    }
 
     // BC: Support deprecated constructor signature without callback
     if (is_array($callback) || null === $callback) {
@@ -81,11 +89,9 @@ class OAuth2Flow extends Flow {
     if (time() < $claims['expires']) return null;
 
     // Refresh token
-    $result= $this->token([
+    $result= $this->token($this->consumer->params($this->tokens) + [
       'grant_type'    => 'refresh_token',
       'refresh_token' => $claims['refresh'],
-      'client_id'     => $this->consumer->key()->reveal(),
-      'client_secret' => $this->consumer->secret()->reveal(),
     ]);
     return new ByAccessToken(
       $result['access_token'],
@@ -143,7 +149,7 @@ class OAuth2Flow extends Flow {
       // Redirect the user to the authorization page
       $params= [
         'response_type' => 'code',
-        'client_id'     => $this->consumer->key()->reveal(),
+        'client_id'     => $this->consumer->clientId,
         'scope'         => implode(' ', $this->scopes),
         'redirect_uri'  => $callback,
         'state'         => $state
@@ -172,10 +178,8 @@ class OAuth2Flow extends Flow {
     if ($state[0] === $stored['state']) {
 
       // Exchange the auth code for an access token
-      $token= $this->token([
+      $token= $this->token($this->consumer->params($this->tokens) + [
         'grant_type'    => 'authorization_code',
-        'client_id'     => $this->consumer->key()->reveal(),
-        'client_secret' => $this->consumer->secret()->reveal(),
         'code'          => $request->param('code'),
         'redirect_uri'  => $callback,
         'state'         => $stored['state']

--- a/src/main/php/web/auth/oauth/OAuth2Flow.class.php
+++ b/src/main/php/web/auth/oauth/OAuth2Flow.class.php
@@ -149,7 +149,7 @@ class OAuth2Flow extends Flow {
       // Redirect the user to the authorization page
       $params= [
         'response_type' => 'code',
-        'client_id'     => $this->consumer->clientId,
+        'client_id'     => $this->consumer->key,
         'scope'         => implode(' ', $this->scopes),
         'redirect_uri'  => $callback,
         'state'         => $state

--- a/src/main/php/web/auth/oauth/Signature.class.php
+++ b/src/main/php/web/auth/oauth/Signature.class.php
@@ -17,13 +17,13 @@ class Signature {
       'oauth_version'          => '1.0',
       'oauth_nonce'            => md5(microtime(true)),
       'oauth_timestamp'        => time(),
-      'oauth_consumer_key'     => $this->consumer->clientId,
+      'oauth_consumer_key'     => $this->consumer->key,
       'oauth_signature_method' => 'HMAC-SHA1',
     ];
 
     $key= rawurlencode($this->consumer->secret()->reveal()).'&';
     if ($this->token) {
-      $parameters+= ['oauth_token' => $this->token->clientId];
+      $parameters+= ['oauth_token' => $this->token->key];
       $key.= rawurlencode($this->token->secret()->reveal());
     }
 

--- a/src/main/php/web/auth/oauth/Signature.class.php
+++ b/src/main/php/web/auth/oauth/Signature.class.php
@@ -3,12 +3,12 @@
 class Signature {
   private $consumer, $token;
 
-  public function __construct(Token $consumer, Token $token= null) {
+  public function __construct(BySecret $consumer, BySecret $token= null) {
     $this->consumer= $consumer;
     $this->token= $token;
   }
 
-  public function with(Token $token) {
+  public function with(BySecret $token) {
     return new self($this->consumer, $token);
   }
 
@@ -17,13 +17,13 @@ class Signature {
       'oauth_version'          => '1.0',
       'oauth_nonce'            => md5(microtime(true)),
       'oauth_timestamp'        => time(),
-      'oauth_consumer_key'     => $this->consumer->key()->reveal(),
+      'oauth_consumer_key'     => $this->consumer->clientId,
       'oauth_signature_method' => 'HMAC-SHA1',
     ];
 
     $key= rawurlencode($this->consumer->secret()->reveal()).'&';
     if ($this->token) {
-      $parameters+= ['oauth_token' => $this->token->key()->reveal()];
+      $parameters+= ['oauth_token' => $this->token->clientId];
       $key.= rawurlencode($this->token->secret()->reveal());
     }
 

--- a/src/main/php/web/auth/oauth/Token.class.php
+++ b/src/main/php/web/auth/oauth/Token.class.php
@@ -2,6 +2,7 @@
 
 use util\Secret;
 
+/** @deprecated Use web.auth.oauth.BySecret instead */
 class Token {
   private $key, $secret;
 

--- a/src/test/php/web/auth/unittest/ByCertificateTest.class.php
+++ b/src/test/php/web/auth/unittest/ByCertificateTest.class.php
@@ -1,0 +1,70 @@
+<?php namespace web\auth\unittest;
+
+use lang\IllegalArgumentException;
+use test\{Assert, Before, Expect, Test, Values};
+use test\verify\Runtime;
+use web\auth\oauth\ByCertificate;
+
+#[Runtime(extensions: ['openssl'])]
+class ByCertificateTest {
+  const CLIENT_ID   = 'b2ba8814';
+  const FINGERPRINT = 'd41d8cd98f00b204e9800998ecf8427e';
+  const ENDPOINT    = 'https://login.example.com/oauth/token';
+
+  private $privateKey;
+
+  #[Before]
+  public function privateKey() {
+    $this->privateKey= openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+  }
+
+  #[Test]
+  public function can_create() {
+    new ByCertificate(self::CLIENT_ID, self::FINGERPRINT, $this->privateKey);
+  }
+
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function invalid_private_key() {
+    new ByCertificate(self::CLIENT_ID, self::FINGERPRINT, 'not.a.private.key');
+  }
+
+  #[Test]
+  public function clientId_member() {
+    Assert::equals(self::CLIENT_ID, (new ByCertificate(self::CLIENT_ID, self::FINGERPRINT, $this->privateKey))->clientId);
+  }
+
+  #[Test]
+  public function client_id_and_assertion_type_in_params() {
+    $params= (new ByCertificate(self::CLIENT_ID, self::FINGERPRINT, $this->privateKey))->params(self::ENDPOINT);
+
+    Assert::equals(self::CLIENT_ID, $params['client_id']);
+    Assert::equals('urn:ietf:params:oauth:client-assertion-type:jwt-bearer', $params['client_assertion_type']);
+  }
+
+  #[Test, Values(['d41d8cd98f00b204', 'D41D8CD98F00B204', 'D4:1D:8C:D9:8F:00:B2:04'])]
+  public function jwt_headers_with($fingerprint) {
+    $params= (new ByCertificate(self::CLIENT_ID, $fingerprint, $this->privateKey))->params(self::ENDPOINT);
+    $headers= json_decode(base64_decode(explode('.', $params['client_assertion'])[0]), true);
+
+    Assert::equals(['alg' => 'RS256', 'typ' => 'JWT', 'x5t' => '1B2M2Y8AsgQ'], $headers);
+  }
+
+  #[Test, Values([3600, 86400])]
+  public function jwt_payload_with($validity) {
+    $time= time();
+    $params= (new ByCertificate(self::CLIENT_ID, self::FINGERPRINT, $this->privateKey, $validity))->params(self::ENDPOINT, $time);
+    $payload= json_decode(base64_decode(explode('.', $params['client_assertion'])[1]), true);
+
+    Assert::equals(
+      [
+        'aud' => self::ENDPOINT,
+        'exp' => $time + $validity,
+        'iss' => self::CLIENT_ID,
+        'jti' => $payload['jti'],  // Random time-based UUID
+        'nbf' => $time,
+        'sub' => self::CLIENT_ID,
+      ],
+      $payload
+    );
+  }
+}

--- a/src/test/php/web/auth/unittest/ByCertificateTest.class.php
+++ b/src/test/php/web/auth/unittest/ByCertificateTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace web\auth\unittest;
 
-use lang\IllegalArgumentException;
-use test\{Assert, Before, Expect, Test, Values};
+use lang\{IllegalArgumentException, IllegalStateException};
 use test\verify\Runtime;
+use test\{Assert, Before, Expect, Test, Values};
 use web\auth\oauth\ByCertificate;
 
 #[Runtime(extensions: ['openssl'])]
@@ -11,16 +11,18 @@ class ByCertificateTest {
   const FINGERPRINT = 'd41d8cd98f00b204e9800998ecf8427e';
   const ENDPOINT    = 'https://login.example.com/oauth/token';
 
-  private $privateKey;
+  private $key;
 
   #[Before]
-  public function privateKey() {
-    $this->privateKey= openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+  public function key() {
+    if (!($this->key= openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]))) {
+      throw new IllegalStateException('Cannot generate private key: '.openssl_error_string());
+    }
   }
 
   #[Test]
   public function can_create() {
-    new ByCertificate(self::CLIENT_ID, self::FINGERPRINT, $this->privateKey);
+    new ByCertificate(self::CLIENT_ID, self::FINGERPRINT, $this->key);
   }
 
   #[Test, Expect(IllegalArgumentException::class)]
@@ -30,12 +32,12 @@ class ByCertificateTest {
 
   #[Test]
   public function clientId_member() {
-    Assert::equals(self::CLIENT_ID, (new ByCertificate(self::CLIENT_ID, self::FINGERPRINT, $this->privateKey))->clientId);
+    Assert::equals(self::CLIENT_ID, (new ByCertificate(self::CLIENT_ID, self::FINGERPRINT, $this->key))->clientId);
   }
 
   #[Test]
   public function client_id_and_assertion_type_in_params() {
-    $params= (new ByCertificate(self::CLIENT_ID, self::FINGERPRINT, $this->privateKey))->params(self::ENDPOINT);
+    $params= (new ByCertificate(self::CLIENT_ID, self::FINGERPRINT, $this->key))->params(self::ENDPOINT);
 
     Assert::equals(self::CLIENT_ID, $params['client_id']);
     Assert::equals('urn:ietf:params:oauth:client-assertion-type:jwt-bearer', $params['client_assertion_type']);
@@ -43,7 +45,7 @@ class ByCertificateTest {
 
   #[Test, Values(['d41d8cd98f00b204', 'D41D8CD98F00B204', 'D4:1D:8C:D9:8F:00:B2:04'])]
   public function jwt_headers_with($fingerprint) {
-    $params= (new ByCertificate(self::CLIENT_ID, $fingerprint, $this->privateKey))->params(self::ENDPOINT);
+    $params= (new ByCertificate(self::CLIENT_ID, $fingerprint, $this->key))->params(self::ENDPOINT);
     $headers= json_decode(base64_decode(explode('.', $params['client_assertion'])[0]), true);
 
     Assert::equals(['alg' => 'RS256', 'typ' => 'JWT', 'x5t' => '1B2M2Y8AsgQ'], $headers);
@@ -52,7 +54,7 @@ class ByCertificateTest {
   #[Test, Values([3600, 86400])]
   public function jwt_payload_with($validity) {
     $time= time();
-    $params= (new ByCertificate(self::CLIENT_ID, self::FINGERPRINT, $this->privateKey, $validity))->params(self::ENDPOINT, $time);
+    $params= (new ByCertificate(self::CLIENT_ID, self::FINGERPRINT, $this->key, $validity))->params(self::ENDPOINT, $time);
     $payload= json_decode(base64_decode(explode('.', $params['client_assertion'])[1]), true);
 
     Assert::equals(

--- a/src/test/php/web/auth/unittest/ByCertificateTest.class.php
+++ b/src/test/php/web/auth/unittest/ByCertificateTest.class.php
@@ -13,16 +13,16 @@ class ByCertificateTest {
   const FINGERPRINT = 'd41d8cd98f00b204e9800998ecf8427e';
   const ENDPOINT    = 'https://login.example.com/oauth/token';
 
-  private $key;
+  private $privateKey;
 
   #[Before]
   public function key() {
-    $this->key= $this->newPrivateKey();
+    $this->privateKey= $this->newPrivateKey();
   }
 
   #[Test]
   public function can_create() {
-    new ByCertificate(self::CLIENT_ID, self::FINGERPRINT, $this->key);
+    new ByCertificate(self::CLIENT_ID, self::FINGERPRINT, $this->privateKey);
   }
 
   #[Test, Expect(IllegalArgumentException::class)]
@@ -31,13 +31,13 @@ class ByCertificateTest {
   }
 
   #[Test]
-  public function clientId_member() {
-    Assert::equals(self::CLIENT_ID, (new ByCertificate(self::CLIENT_ID, self::FINGERPRINT, $this->key))->clientId);
+  public function key_member() {
+    Assert::equals(self::CLIENT_ID, (new ByCertificate(self::CLIENT_ID, self::FINGERPRINT, $this->privateKey))->key);
   }
 
   #[Test]
   public function client_id_and_assertion_type_in_params() {
-    $params= (new ByCertificate(self::CLIENT_ID, self::FINGERPRINT, $this->key))->params(self::ENDPOINT);
+    $params= (new ByCertificate(self::CLIENT_ID, self::FINGERPRINT, $this->privateKey))->params(self::ENDPOINT);
 
     Assert::equals(self::CLIENT_ID, $params['client_id']);
     Assert::equals('urn:ietf:params:oauth:client-assertion-type:jwt-bearer', $params['client_assertion_type']);
@@ -45,7 +45,7 @@ class ByCertificateTest {
 
   #[Test, Values(['d41d8cd98f00b204', 'D41D8CD98F00B204', 'D4:1D:8C:D9:8F:00:B2:04'])]
   public function jwt_headers_with($fingerprint) {
-    $params= (new ByCertificate(self::CLIENT_ID, $fingerprint, $this->key))->params(self::ENDPOINT);
+    $params= (new ByCertificate(self::CLIENT_ID, $fingerprint, $this->privateKey))->params(self::ENDPOINT);
     $headers= json_decode(base64_decode(explode('.', $params['client_assertion'])[0]), true);
 
     Assert::equals(['alg' => 'RS256', 'typ' => 'JWT', 'x5t' => '1B2M2Y8AsgQ'], $headers);
@@ -54,7 +54,7 @@ class ByCertificateTest {
   #[Test, Values([3600, 86400])]
   public function jwt_payload_with($validity) {
     $time= time();
-    $params= (new ByCertificate(self::CLIENT_ID, self::FINGERPRINT, $this->key, $validity))->params(self::ENDPOINT, $time);
+    $params= (new ByCertificate(self::CLIENT_ID, self::FINGERPRINT, $this->privateKey, $validity))->params(self::ENDPOINT, $time);
     $payload= json_decode(base64_decode(explode('.', $params['client_assertion'])[1]), true);
 
     Assert::equals(

--- a/src/test/php/web/auth/unittest/ByCertificateTest.class.php
+++ b/src/test/php/web/auth/unittest/ByCertificateTest.class.php
@@ -7,6 +7,8 @@ use web\auth\oauth\ByCertificate;
 
 #[Runtime(extensions: ['openssl'])]
 class ByCertificateTest {
+  use PrivateKey;
+
   const CLIENT_ID   = 'b2ba8814';
   const FINGERPRINT = 'd41d8cd98f00b204e9800998ecf8427e';
   const ENDPOINT    = 'https://login.example.com/oauth/token';
@@ -15,9 +17,7 @@ class ByCertificateTest {
 
   #[Before]
   public function key() {
-    if (!($this->key= openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]))) {
-      throw new IllegalStateException('Cannot generate private key: '.openssl_error_string());
-    }
+    $this->key= $this->newPrivateKey();
   }
 
   #[Test]

--- a/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
+++ b/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
@@ -11,11 +11,12 @@ use web\session\ForTesting;
 use web\{Request, Response};
 
 class OAuth2FlowTest extends FlowTest {
-  const AUTH     = 'https://example.com/oauth/authorize';
-  const TOKENS   = 'https://example.com/oauth/access_token';
-  const CONSUMER = ['bf396750', '5ebe2294ecd0e0f08eab7690d2a6ee69'];
-  const SERVICE  = 'https://service.example.com';
-  const CALLBACK = 'https://service.example.com/callback';
+  const AUTH        = 'https://example.com/oauth/authorize';
+  const TOKENS      = 'https://example.com/oauth/access_token';
+  const CONSUMER    = ['bf396750', '5ebe2294ecd0e0f08eab7690d2a6ee69'];
+  const SERVICE     = 'https://service.example.com';
+  const CALLBACK    = 'https://service.example.com/callback';
+  const FINGERPRINT = 'd41d8cd98f00b204e9800998ecf8427e';
 
   /**
    * Asserts a given response redirects to a given OAuth endpoint
@@ -187,7 +188,7 @@ class OAuth2FlowTest extends FlowTest {
   public function passes_client_id_assertion_and_rs256_jwt() {
     $key= openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
 
-    $credentials= new ByCertificate('client-id', 'fingerprint', $key);
+    $credentials= new ByCertificate('client-id', self::FINGERPRINT, $key);
     $state= 'SHAREDSTATE';
     $fixture= newinstance(OAuth2Flow::class, [self::AUTH, self::TOKENS, $credentials, self::CALLBACK], [
       'token' => function($payload) use(&$passed) { $passed= $payload; /* Not implemented */ }

--- a/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
+++ b/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
@@ -1,9 +1,10 @@
 <?php namespace web\auth\unittest;
 
 use lang\IllegalStateException;
+use test\verify\Runtime;
 use test\{Assert, Expect, Test, TestCase, Values};
 use util\URI;
-use web\auth\oauth\{Client, OAuth2Flow};
+use web\auth\oauth\{Client, BySecret, ByCertificate, Token, OAuth2Flow};
 use web\auth\{UseCallback, UseRequest, UseURL};
 use web\io\{TestInput, TestOutput};
 use web\session\ForTesting;
@@ -163,6 +164,43 @@ class OAuth2FlowTest extends FlowTest {
 
     $this->authenticate($fixture, '/', $session);
     Assert::equals('REUSED_STATE', $session->value(OAuth2Flow::SESSION_KEY)['state']);
+  }
+
+  #[Test]
+  public function passes_client_id_and_secret() {
+    $credentials= new BySecret('client-id', 'secret');
+    $state= 'SHAREDSTATE';
+    $fixture= newinstance(OAuth2Flow::class, [self::AUTH, self::TOKENS, $credentials, self::CALLBACK], [
+      'token' => function($payload) use(&$passed) { $passed= $payload; /* Not implemented */ }
+    ]);
+    $session= (new ForTesting())->create();
+    $session->register(OAuth2Flow::SESSION_KEY, ['state' => $state, 'target' => self::SERVICE]);
+
+    $this->authenticate($fixture, '/?code=SERVER_CODE&state='.$state, $session);
+    Assert::equals('authorization_code', $passed['grant_type']);
+    Assert::equals('SERVER_CODE', $passed['code']);
+    Assert::equals('client-id', $passed['client_id']);
+    Assert::equals('secret', $passed['client_secret']);
+  }
+
+  #[Test, Runtime(extensions: ['openssl'])]
+  public function passes_client_id_assertion_and_rs256_jwt() {
+    $key= openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+
+    $credentials= new ByCertificate('client-id', 'fingerprint', $key);
+    $state= 'SHAREDSTATE';
+    $fixture= newinstance(OAuth2Flow::class, [self::AUTH, self::TOKENS, $credentials, self::CALLBACK], [
+      'token' => function($payload) use(&$passed) { $passed= $payload; /* Not implemented */ }
+    ]);
+    $session= (new ForTesting())->create();
+    $session->register(OAuth2Flow::SESSION_KEY, ['state' => $state, 'target' => self::SERVICE]);
+
+    $this->authenticate($fixture, '/?code=SERVER_CODE&state='.$state, $session);
+    Assert::equals('authorization_code', $passed['grant_type']);
+    Assert::equals('SERVER_CODE', $passed['code']);
+    Assert::equals('client-id', $passed['client_id']);
+    Assert::equals('urn:ietf:params:oauth:client-assertion-type:jwt-bearer', $passed['client_assertion_type']);
+    Assert::true(isset($passed['client_assertion']));
   }
 
   #[Test]

--- a/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
+++ b/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
@@ -11,6 +11,8 @@ use web\session\ForTesting;
 use web\{Request, Response};
 
 class OAuth2FlowTest extends FlowTest {
+  use PrivateKey;
+
   const AUTH        = 'https://example.com/oauth/authorize';
   const TOKENS      = 'https://example.com/oauth/access_token';
   const CONSUMER    = ['bf396750', '5ebe2294ecd0e0f08eab7690d2a6ee69'];
@@ -186,11 +188,7 @@ class OAuth2FlowTest extends FlowTest {
 
   #[Test, Runtime(extensions: ['openssl'])]
   public function passes_client_id_assertion_and_rs256_jwt() {
-    if (!($key= openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]))) {
-      throw new IllegalStateException('Cannot generate private key: '.openssl_error_string());
-    }
-
-    $credentials= new ByCertificate('client-id', self::FINGERPRINT, $key);
+    $credentials= new ByCertificate('client-id', self::FINGERPRINT, $this->newPrivateKey());
     $state= 'SHAREDSTATE';
     $fixture= newinstance(OAuth2Flow::class, [self::AUTH, self::TOKENS, $credentials, self::CALLBACK], [
       'token' => function($payload) use(&$passed) { $passed= $payload; /* Not implemented */ }

--- a/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
+++ b/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
@@ -186,7 +186,9 @@ class OAuth2FlowTest extends FlowTest {
 
   #[Test, Runtime(extensions: ['openssl'])]
   public function passes_client_id_assertion_and_rs256_jwt() {
-    $key= openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+    if (!($key= openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]))) {
+      throw new IllegalStateException('Cannot generate private key: '.openssl_error_string());
+    }
 
     $credentials= new ByCertificate('client-id', self::FINGERPRINT, $key);
     $state= 'SHAREDSTATE';

--- a/src/test/php/web/auth/unittest/OAuthBySignedRequestsTest.class.php
+++ b/src/test/php/web/auth/unittest/OAuthBySignedRequestsTest.class.php
@@ -3,7 +3,7 @@
 use io\streams\MemoryInputStream;
 use peer\http\HttpResponse;
 use test\{Assert, Before, Test};
-use web\auth\oauth\{BySignedRequests, Signature, Token};
+use web\auth\oauth\{BySignedRequests, Signature, BySecret};
 
 class OAuthBySignedRequestsTest {
   private $signature;
@@ -23,7 +23,7 @@ class OAuthBySignedRequestsTest {
 
   #[Before]
   public function initialize() {
-    $this->signature= new class(new Token('consumer', '073204f68de382213e92c5792b07b33b')) extends Signature {
+    $this->signature= new class(new BySecret('consumer', '073204f68de382213e92c5792b07b33b')) extends Signature {
       public function header($method, $url, $parameters= []) {
         return parent::header($method, $url, $parameters + [
           'oauth_nonce'     => '90a8e9e6d5d4fb731eec44a8ee9dcb65',

--- a/src/test/php/web/auth/unittest/PrivateKey.class.php
+++ b/src/test/php/web/auth/unittest/PrivateKey.class.php
@@ -1,0 +1,38 @@
+<?php namespace web\auth\unittest;
+
+use lang\IllegalStateException;
+
+trait PrivateKey {
+
+  /**
+   * Creates a new 2048 bits RSA private key.
+   * 
+   * @return OpenSSLAsymmetricKey
+   * @throws lang.IllegalStateException
+   */
+  public function newPrivateKey() {
+    $options= ['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA];
+
+    // On Windows, search common locations for openssl.cnf *including*
+    // the sample config bundled with the PHP release in `extras/ssl`
+    if (0 === strncasecmp(PHP_OS, 'WIN', 3)) {
+      $locations= [
+        getenv('OPENSSL_CONF') ?: getenv('SSLEAY_CONF'),
+        'C:\\Program Files\\Common Files\\SSL\\openssl.cnf',
+        'C:\\Program Files (x86)\\Common Files\\SSL\\openssl.cnf',
+        dirname(PHP_BINARY).'\\extras\\ssl\\openssl.cnf'
+      ];
+      foreach ($locations as $location) {
+        if (!file_exists($location)) continue;
+        $options['config']= $location;
+        break;
+      }
+    }
+
+    if (!($key= openssl_pkey_new($options))) {
+      throw new IllegalStateException('Cannot generate private key: '.openssl_error_string());
+    }
+
+    return $key;
+  }
+}


### PR DESCRIPTION
## Using client ID and secret

```php
use web\auth\oauth\{OAuth2Flow, BySecret};

$flow= new OAuth2Flow(
  'https://login.example.com/oauth2/v2.0/authorize',
  'https://login.example.com/oauth2/v2.0/token',
  new BySecret(
    clientId: 'b2ba8814',
    secret: new Secret(/* ... */),
  ),
  callback: '/',
);
```

## Using client ID, certificate fingerprint and private key

```php
use web\auth\oauth\{OAuth2Flow, ByCertificate};

$flow= new OAuth2Flow(
  'https://login.example.com/oauth2/v2.0/authorize',
  'https://login.example.com/oauth2/v2.0/token',
  new ByCertificate(
    clientId: 'b2ba8814',
    fingerprint: 'd41d8cd98f00b204e9800998ecf8427e',
    'file://private.key'
  ),
  callback: '/',
);
```

## See also:

* #17
* https://tools.ietf.org/html/rfc7523
* https://stackoverflow.com/questions/59216430/how-can-i-sign-a-jwt-to-exchange-an-access-token-from-azure-active-directory/59243050#59243050