### PR TITLE
Extract OAuth 2 backend interaction into dedicated class

### DIFF
--- a/src/main/php/web/auth/oauth/Credentials.class.php
+++ b/src/main/php/web/auth/oauth/Credentials.class.php
@@ -1,13 +1,23 @@
 <?php namespace web\auth\oauth;
 
+use lang\IllegalStateException;
+
 abstract class Credentials {
+  public static $UNSET;
   public $key;
 
+  static function __static() {
+    self::$UNSET= new class(null) extends Credentials {
+      public function params(string $endpoint, int $time= null): array {
+        throw new IllegalStateException('No credentials set');
+      }
+    };
+  }
+
   /**
-   * Creates credentials with a client ID and secret
+   * Creates credentials with a client ID
    *
-   * @param  string $key
-   * @param  string|util.Secret $secret
+   * @param  ?string $key
    */
   public function __construct($key) {
     $this->key= $key;

--- a/src/main/php/web/auth/oauth/OAuth2Backend.class.php
+++ b/src/main/php/web/auth/oauth/OAuth2Backend.class.php
@@ -16,7 +16,7 @@ class OAuth2Backend {
    */
   public function __construct($endpoint, $credentials= null) {
     $this->conn= $endpoint instanceof HttpConnection ? $endpoint : new HttpConnection($endpoint);
-    $credentials && $this->using($credentials);
+    $this->using($credentials ?? Credentials::$UNSET);
   }
 
   /**

--- a/src/main/php/web/auth/oauth/OAuth2Backend.class.php
+++ b/src/main/php/web/auth/oauth/OAuth2Backend.class.php
@@ -1,0 +1,80 @@
+<?php namespace web\auth\oauth;
+
+use peer\http\HttpConnection;
+use lang\IllegalStateException;
+use io\streams\Streams;
+
+class OAuth2Backend {
+  private $conn, $credentials;
+  private $headers= [];
+
+  /**
+   * Creates a new OAuth 2 backend
+   *
+   * @param  string|util.URI $endpoint
+   * @param  web.auth.oauth.Credentials|(string|util.Secret)[] $credentials
+   */
+  public function __construct($endpoint, $credentials) {
+    $this->conn= new HttpConnection($endpoint);
+
+    // BC: Support web.auth.oauth.Token instances
+    if ($credentials instanceof Credentials) {
+      $this->credentials= $credentials;
+    } else if ($credentials instanceof Token) {
+      $this->credentials= new BySecret($credentials->key()->reveal(), $credentials->secret());
+    } else {
+      $this->credentials= new BySecret(...$credentials);
+    }
+  }
+
+  /**
+   * Specifies headers to add to request
+   *
+   * @param  [:string] $headers
+   * @return self
+   */
+  public function with($headers) {
+    $this->headers= $headers;
+    return $this;
+  }
+
+  /** @return string */
+  public function clientId() { return $this->credentials->key; }
+
+  /**
+   * Performs HTTP request
+   *
+   * @param  [:string] $payload POST parameters
+   * @return [:string] Token
+   * @throws lang.IllegalStateException
+   */
+  protected function request($payload) {
+    $r= $this->conn->post($payload, $this->headers + [
+      'Accept'     => 'application/x-www-form-urlencoded, application/json',
+      'User-Agent' => 'XP/OAuth2'
+    ]);
+
+    $body= Streams::readAll($r->in());
+    if (200 !== $r->statusCode()) {
+      throw new IllegalStateException('Cannot get access token (#'.$r->statusCode().'): '.$body);
+    }
+
+    $type= $r->header('Content-Type')[0];
+    if (strstr($type, 'application/json')) {
+      return json_decode($body, true);
+    } else {
+      parse_str($body, $token);
+      return $token;
+    }
+  }
+
+  /**
+   * Acquires a grant
+   *
+   * @param  [:string] $grant
+   * @return [:string]
+   */
+  public function acquire($grant) {
+    return $this->request($this->credentials->params($this->conn->getUrl()->getCanonicalURL()) + $grant);
+  }
+}

--- a/src/main/php/web/auth/oauth/OAuth2Backend.class.php
+++ b/src/main/php/web/auth/oauth/OAuth2Backend.class.php
@@ -12,19 +12,28 @@ class OAuth2Backend {
    * Creates a new OAuth 2 backend
    *
    * @param  string|util.URI|peer.http.HttpConnection $endpoint
-   * @param  web.auth.oauth.Credentials|(string|util.Secret)[] $credentials
+   * @param  ?web.auth.oauth.Credentials|(string|util.Secret)[] $credentials
    */
-  public function __construct($endpoint, $credentials) {
+  public function __construct($endpoint, $credentials= null) {
     $this->conn= $endpoint instanceof HttpConnection ? $endpoint : new HttpConnection($endpoint);
+    $credentials && $this->using($credentials);
+  }
 
-    // BC: Support web.auth.oauth.Token instances
+  /**
+   * Specifies credentials to use
+   *
+   * @param  web.auth.oauth.Credentials|(string|util.Secret)[] $credentials
+   * @return self
+   */
+  public function using($credentials) {
     if ($credentials instanceof Credentials) {
       $this->credentials= $credentials;
-    } else if ($credentials instanceof Token) {
+    } else if ($credentials instanceof Token) { // BC
       $this->credentials= new BySecret($credentials->key()->reveal(), $credentials->secret());
     } else {
       $this->credentials= new BySecret(...$credentials);
     }
+    return $this;
   }
 
   /**

--- a/src/main/php/web/auth/oauth/OAuth2Backend.class.php
+++ b/src/main/php/web/auth/oauth/OAuth2Backend.class.php
@@ -11,11 +11,11 @@ class OAuth2Backend {
   /**
    * Creates a new OAuth 2 backend
    *
-   * @param  string|util.URI $endpoint
+   * @param  string|util.URI|peer.http.HttpConnection $endpoint
    * @param  web.auth.oauth.Credentials|(string|util.Secret)[] $credentials
    */
   public function __construct($endpoint, $credentials) {
-    $this->conn= new HttpConnection($endpoint);
+    $this->conn= $endpoint instanceof HttpConnection ? $endpoint : new HttpConnection($endpoint);
 
     // BC: Support web.auth.oauth.Token instances
     if ($credentials instanceof Credentials) {

--- a/src/main/php/web/auth/oauth/OAuth2Endpoint.class.php
+++ b/src/main/php/web/auth/oauth/OAuth2Endpoint.class.php
@@ -4,7 +4,7 @@ use peer\http\HttpConnection;
 use lang\IllegalStateException;
 use io\streams\Streams;
 
-class OAuth2Backend {
+class OAuth2Endpoint {
   private $conn, $credentials;
   private $headers= [];
 

--- a/src/main/php/web/auth/oauth/OAuth2Flow.class.php
+++ b/src/main/php/web/auth/oauth/OAuth2Flow.class.php
@@ -10,29 +10,20 @@ use web\session\Sessions;
 class OAuth2Flow extends Flow {
   const SESSION_KEY = 'oauth2::flow';
 
-  private $auth, $tokens, $consumer, $scopes, $callback, $rand;
+  private $auth, $backend, $scopes, $callback, $rand;
 
   /**
    * Creates a new OAuth 2 flow
    *
    * @param  string|util.URI $auth
-   * @param  string|util.URI $tokens
-   * @param  web.auth.oauth.Credentials|(string|util.Secret)[] $consumer
+   * @param  string|util.URI|web.auth.oauth.OAuth2Backend $tokens
+   * @param  ?web.auth.oauth.Credentials|(string|util.Secret)[] $consumer
    * @param  string|util.URI $callback
    * @param  string[] $scopes
    */
   public function __construct($auth, $tokens, $consumer, $callback= null, $scopes= ['user']) {
     $this->auth= $auth instanceof URI ? $auth : new URI($auth);
-    $this->tokens= $tokens instanceof URI ? $tokens : new URI($tokens);
-
-    // BC: Support web.auth.oauth.Token instances
-    if ($consumer instanceof Credentials) {
-      $this->consumer= $consumer;
-    } else if ($consumer instanceof Token) {
-      $this->consumer= new BySecret($consumer->key()->reveal(), $consumer->secret());
-    } else {
-      $this->consumer= new BySecret(...$consumer);
-    }
+    $this->backend= $tokens instanceof OAuth2Backend ? $tokens : new OAuth2Backend($tokens, $consumer);
 
     // BC: Support deprecated constructor signature without callback
     if (is_array($callback) || null === $callback) {
@@ -54,31 +45,6 @@ class OAuth2Flow extends Flow {
   public function scopes() { return $this->scopes; }
 
   /**
-   * Gets a token
-   *
-   * @param  [:string] $payload POST parameters
-   * @return [:string] Token
-   * @throws lang.IllegalStateException
-   */
-  protected function token($payload) {
-    $c= new HttpConnection($this->tokens);
-    $r= $c->post($payload, ['Accept' => 'application/x-www-form-urlencoded, application/json', 'User-Agent' => 'XP/OAuth2']);
-
-    $body= Streams::readAll($r->in());
-    if (200 !== $r->statusCode()) {
-      throw new IllegalStateException('Cannot get access token (#'.$r->statusCode().'): '.$body);
-    }
-
-    $type= $r->header('Content-Type')[0];
-    if (strstr($type, 'application/json')) {
-      return json_decode($body, true);
-    } else {
-      parse_str($body, $token);
-      return $token;
-    }
-  }
-
-  /**
    * Refreshes access token given a refresh token if necessary.
    *
    * @param  [:var] $claims
@@ -89,7 +55,7 @@ class OAuth2Flow extends Flow {
     if (time() < $claims['expires']) return null;
 
     // Refresh token
-    $result= $this->token($this->consumer->params($this->tokens) + [
+    $result= $this->backend->acquire([
       'grant_type'    => 'refresh_token',
       'refresh_token' => $claims['refresh'],
     ]);
@@ -149,7 +115,7 @@ class OAuth2Flow extends Flow {
       // Redirect the user to the authorization page
       $params= [
         'response_type' => 'code',
-        'client_id'     => $this->consumer->key,
+        'client_id'     => $this->backend->clientId(),
         'scope'         => implode(' ', $this->scopes),
         'redirect_uri'  => $callback,
         'state'         => $state
@@ -178,7 +144,7 @@ class OAuth2Flow extends Flow {
     if ($state[0] === $stored['state']) {
 
       // Exchange the auth code for an access token
-      $token= $this->token($this->consumer->params($this->tokens) + [
+      $token= $this->backend->acquire([
         'grant_type'    => 'authorization_code',
         'code'          => $request->param('code'),
         'redirect_uri'  => $callback,

--- a/src/main/php/web/auth/oauth/OAuth2Flow.class.php
+++ b/src/main/php/web/auth/oauth/OAuth2Flow.class.php
@@ -23,7 +23,10 @@ class OAuth2Flow extends Flow {
    */
   public function __construct($auth, $tokens, $consumer, $callback= null, $scopes= ['user']) {
     $this->auth= $auth instanceof URI ? $auth : new URI($auth);
-    $this->backend= $tokens instanceof OAuth2Backend ? $tokens : new OAuth2Backend($tokens, $consumer);
+    $this->backend= $tokens instanceof OAuth2Backend
+      ? $tokens->using($consumer)
+      : new OAuth2Backend($tokens, $consumer)
+    ;
 
     // BC: Support deprecated constructor signature without callback
     if (is_array($callback) || null === $callback) {

--- a/src/main/php/web/auth/oauth/OAuth2Flow.class.php
+++ b/src/main/php/web/auth/oauth/OAuth2Flow.class.php
@@ -16,16 +16,16 @@ class OAuth2Flow extends Flow {
    * Creates a new OAuth 2 flow
    *
    * @param  string|util.URI $auth
-   * @param  string|util.URI|web.auth.oauth.OAuth2Backend $tokens
+   * @param  string|util.URI|web.auth.oauth.OAuth2Endpoint $tokens
    * @param  ?web.auth.oauth.Credentials|(string|util.Secret)[] $consumer
    * @param  string|util.URI $callback
    * @param  string[] $scopes
    */
   public function __construct($auth, $tokens, $consumer, $callback= null, $scopes= ['user']) {
     $this->auth= $auth instanceof URI ? $auth : new URI($auth);
-    $this->backend= $tokens instanceof OAuth2Backend
+    $this->backend= $tokens instanceof OAuth2Endpoint
       ? $tokens->using($consumer)
-      : new OAuth2Backend($tokens, $consumer)
+      : new OAuth2Endpoint($tokens, $consumer)
     ;
 
     // BC: Support deprecated constructor signature without callback

--- a/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
+++ b/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
@@ -173,7 +173,7 @@ class OAuth2FlowTest extends FlowTest {
   public function passes_client_id_and_secret() {
     $credentials= new BySecret('client-id', 'secret');
     $state= 'SHAREDSTATE';
-    $tokens= newinstance(OAuth2Backend::class, [self::TOKENS, $credentials], [
+    $tokens= newinstance(OAuth2Backend::class, [self::TOKENS], [
       'request' => function($payload) use(&$passed) { $passed= $payload; /* Not implemented */ }
     ]);
     $fixture= new OAuth2Flow(self::AUTH, $tokens, $credentials, self::CALLBACK);
@@ -191,7 +191,7 @@ class OAuth2FlowTest extends FlowTest {
   public function passes_client_id_assertion_and_rs256_jwt() {
     $credentials= new ByCertificate('client-id', self::FINGERPRINT, $this->newPrivateKey());
     $state= 'SHAREDSTATE';
-    $tokens= newinstance(OAuth2Backend::class, [self::TOKENS, $credentials], [
+    $tokens= newinstance(OAuth2Backend::class, [self::TOKENS], [
       'request' => function($payload) use(&$passed) { $passed= $payload; /* Not implemented */ }
     ]);
     $fixture= new OAuth2Flow(self::AUTH, $tokens, $credentials, self::CALLBACK);
@@ -210,7 +210,7 @@ class OAuth2FlowTest extends FlowTest {
   public function gets_access_token_and_redirects_to_self() {
     $token= ['access_token' => '<TOKEN>', 'token_type' => 'Bearer'];
     $state= 'SHAREDSTATE';
-    $tokens= newinstance(OAuth2Backend::class, [self::TOKENS, self::CONSUMER], [
+    $tokens= newinstance(OAuth2Backend::class, [self::TOKENS], [
       'request' => function($payload) use($token) { return $token; }
     ]);
     $fixture= new OAuth2Flow(self::AUTH, $tokens, self::CONSUMER, self::CALLBACK);
@@ -226,7 +226,7 @@ class OAuth2FlowTest extends FlowTest {
   public function gets_access_token_and_redirects_to_self_with_fragment($fragment) {
     $token= ['access_token' => '<TOKEN>', 'token_type' => 'Bearer'];
     $state= 'SHAREDSTATE';
-    $tokens= newinstance(OAuth2Backend::class, [self::TOKENS, self::CONSUMER], [
+    $tokens= newinstance(OAuth2Backend::class, [self::TOKENS], [
       'request' => function($payload) use($token) { return $token; }
     ]);
     $fixture= new OAuth2Flow(self::AUTH, $tokens, self::CONSUMER, self::CALLBACK);

--- a/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
+++ b/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
@@ -4,7 +4,7 @@ use lang\IllegalStateException;
 use test\verify\Runtime;
 use test\{Assert, Expect, Test, TestCase, Values};
 use util\URI;
-use web\auth\oauth\{Client, BySecret, ByCertificate, Token, OAuth2Flow, OAuth2Backend};
+use web\auth\oauth\{Client, BySecret, ByCertificate, Token, OAuth2Flow, OAuth2Endpoint};
 use web\auth\{UseCallback, UseRequest, UseURL};
 use web\io\{TestInput, TestOutput};
 use web\session\ForTesting;
@@ -173,7 +173,7 @@ class OAuth2FlowTest extends FlowTest {
   public function passes_client_id_and_secret() {
     $credentials= new BySecret('client-id', 'secret');
     $state= 'SHAREDSTATE';
-    $tokens= newinstance(OAuth2Backend::class, [self::TOKENS], [
+    $tokens= newinstance(OAuth2Endpoint::class, [self::TOKENS], [
       'request' => function($payload) use(&$passed) { $passed= $payload; /* Not implemented */ }
     ]);
     $fixture= new OAuth2Flow(self::AUTH, $tokens, $credentials, self::CALLBACK);
@@ -191,7 +191,7 @@ class OAuth2FlowTest extends FlowTest {
   public function passes_client_id_assertion_and_rs256_jwt() {
     $credentials= new ByCertificate('client-id', self::FINGERPRINT, $this->newPrivateKey());
     $state= 'SHAREDSTATE';
-    $tokens= newinstance(OAuth2Backend::class, [self::TOKENS], [
+    $tokens= newinstance(OAuth2Endpoint::class, [self::TOKENS], [
       'request' => function($payload) use(&$passed) { $passed= $payload; /* Not implemented */ }
     ]);
     $fixture= new OAuth2Flow(self::AUTH, $tokens, $credentials, self::CALLBACK);
@@ -210,7 +210,7 @@ class OAuth2FlowTest extends FlowTest {
   public function gets_access_token_and_redirects_to_self() {
     $token= ['access_token' => '<TOKEN>', 'token_type' => 'Bearer'];
     $state= 'SHAREDSTATE';
-    $tokens= newinstance(OAuth2Backend::class, [self::TOKENS], [
+    $tokens= newinstance(OAuth2Endpoint::class, [self::TOKENS], [
       'request' => function($payload) use($token) { return $token; }
     ]);
     $fixture= new OAuth2Flow(self::AUTH, $tokens, self::CONSUMER, self::CALLBACK);
@@ -226,7 +226,7 @@ class OAuth2FlowTest extends FlowTest {
   public function gets_access_token_and_redirects_to_self_with_fragment($fragment) {
     $token= ['access_token' => '<TOKEN>', 'token_type' => 'Bearer'];
     $state= 'SHAREDSTATE';
-    $tokens= newinstance(OAuth2Backend::class, [self::TOKENS], [
+    $tokens= newinstance(OAuth2Endpoint::class, [self::TOKENS], [
       'request' => function($payload) use($token) { return $token; }
     ]);
     $fixture= new OAuth2Flow(self::AUTH, $tokens, self::CONSUMER, self::CALLBACK);

--- a/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
+++ b/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
@@ -4,7 +4,7 @@ use lang\IllegalStateException;
 use test\verify\Runtime;
 use test\{Assert, Expect, Test, TestCase, Values};
 use util\URI;
-use web\auth\oauth\{Client, BySecret, ByCertificate, Token, OAuth2Flow};
+use web\auth\oauth\{Client, BySecret, ByCertificate, Token, OAuth2Flow, OAuth2Backend};
 use web\auth\{UseCallback, UseRequest, UseURL};
 use web\io\{TestInput, TestOutput};
 use web\session\ForTesting;
@@ -173,9 +173,10 @@ class OAuth2FlowTest extends FlowTest {
   public function passes_client_id_and_secret() {
     $credentials= new BySecret('client-id', 'secret');
     $state= 'SHAREDSTATE';
-    $fixture= newinstance(OAuth2Flow::class, [self::AUTH, self::TOKENS, $credentials, self::CALLBACK], [
-      'token' => function($payload) use(&$passed) { $passed= $payload; /* Not implemented */ }
+    $tokens= newinstance(OAuth2Backend::class, [self::TOKENS, $credentials], [
+      'request' => function($payload) use(&$passed) { $passed= $payload; /* Not implemented */ }
     ]);
+    $fixture= new OAuth2Flow(self::AUTH, $tokens, $credentials, self::CALLBACK);
     $session= (new ForTesting())->create();
     $session->register(OAuth2Flow::SESSION_KEY, ['state' => $state, 'target' => self::SERVICE]);
 
@@ -190,9 +191,10 @@ class OAuth2FlowTest extends FlowTest {
   public function passes_client_id_assertion_and_rs256_jwt() {
     $credentials= new ByCertificate('client-id', self::FINGERPRINT, $this->newPrivateKey());
     $state= 'SHAREDSTATE';
-    $fixture= newinstance(OAuth2Flow::class, [self::AUTH, self::TOKENS, $credentials, self::CALLBACK], [
-      'token' => function($payload) use(&$passed) { $passed= $payload; /* Not implemented */ }
+    $tokens= newinstance(OAuth2Backend::class, [self::TOKENS, $credentials], [
+      'request' => function($payload) use(&$passed) { $passed= $payload; /* Not implemented */ }
     ]);
+    $fixture= new OAuth2Flow(self::AUTH, $tokens, $credentials, self::CALLBACK);
     $session= (new ForTesting())->create();
     $session->register(OAuth2Flow::SESSION_KEY, ['state' => $state, 'target' => self::SERVICE]);
 
@@ -208,9 +210,10 @@ class OAuth2FlowTest extends FlowTest {
   public function gets_access_token_and_redirects_to_self() {
     $token= ['access_token' => '<TOKEN>', 'token_type' => 'Bearer'];
     $state= 'SHAREDSTATE';
-    $fixture= newinstance(OAuth2Flow::class, [self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK], [
-      'token' => function($payload) use($token) { return $token; }
+    $tokens= newinstance(OAuth2Backend::class, [self::TOKENS, self::CONSUMER], [
+      'request' => function($payload) use($token) { return $token; }
     ]);
+    $fixture= new OAuth2Flow(self::AUTH, $tokens, self::CONSUMER, self::CALLBACK);
     $session= (new ForTesting())->create();
     $session->register(OAuth2Flow::SESSION_KEY, ['state' => $state, 'target' => self::SERVICE]);
 
@@ -223,9 +226,10 @@ class OAuth2FlowTest extends FlowTest {
   public function gets_access_token_and_redirects_to_self_with_fragment($fragment) {
     $token= ['access_token' => '<TOKEN>', 'token_type' => 'Bearer'];
     $state= 'SHAREDSTATE';
-    $fixture= newinstance(OAuth2Flow::class, [self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK], [
-      'token' => function($payload) use($token) { return $token; }
+    $tokens= newinstance(OAuth2Backend::class, [self::TOKENS, self::CONSUMER], [
+      'request' => function($payload) use($token) { return $token; }
     ]);
+    $fixture= new OAuth2Flow(self::AUTH, $tokens, self::CONSUMER, self::CALLBACK);
     $session= (new ForTesting())->create();
     $session->register(OAuth2Flow::SESSION_KEY, ['state' => $state, 'target' => self::SERVICE]);
 


### PR DESCRIPTION
The `OAuth2Endpoint` class is used by the `OAuthFlow` implementation, but can also be used standalone, e.g.:

```php
use util\URI;
use webservices\rest\Endpoint;
use web\auth\oauth\{OAuth2Endpoint, Credentials};

class GraphApi {
  private const BASE= 'https://graph.microsoft.com';
  private $auth;

  public function __construct(string $tenant, Credentials $credentials) {
    $this->auth= new OAuth2Endpoint(
      "https://login.microsoftonline.com/{$tenant}/oauth2/token",
      $credentials
    );
  }

  /** Authenticates and returns an endpoint with the `Authorization` header. */
  public function endpoint(string $uri): Endpoint {
    $token= $this->auth->acquire([
      'grant_type' => 'client_credentials',
      'resource'   => self::BASE
    ]);

    return new Endpoint(self::BASE.$uri)->with(['Authorization' => $token['token_type'].' '.$token['access_token']]);
  }
}

$graph= new GraphApi($tenant, $credentials);

// Use https://learn.microsoft.com/en-us/graph/api/user-sendmail?view=graph-rest-1.0&tabs=http
$endpoint= $graph->endpoint('/v1.0');
$result= $endpoint->resource('users/test@example.com/sendMail')->post($mail, 'application/json');
```