### PR TITLE
Refactor CAS authentication flow to use address library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require" : {
     "xp-framework/core": "^12.0 | ^11.0 | ^10.0",
     "xp-framework/http": "^10.0 | ^9.0 | ^8.0 | ^7.0",
-    "xp-framework/xml": "^12.0 | ^11.0 | ^10.0 | ^9.0 | ^8.0",
+    "xp-forge/address": "^6.0 | ^5.3",
     "xp-forge/web": "^4.0 | ^3.0 | ^2.0 | ^1.0",
     "xp-forge/json": "^5.0 | ^4.0 | ^3.1",
     "xp-forge/sessions": "^3.0 | ^2.0 | ^1.0",

--- a/src/main/php/web/auth/cas/CasFlow.class.php
+++ b/src/main/php/web/auth/cas/CasFlow.class.php
@@ -93,10 +93,10 @@ class CasFlow extends Flow {
               $self+= yield new ValueOf([], ['*' => function(&$self, $name) {
                 $self[str_replace('cas:', '', $name)]= yield;
               }]);
-            }
-          ])
+            },
+          ]);
         },
-        '*' => function(&$self, $name) { $self[$name]= yield; }
+        '*' => function(&$self, $name) { $self[$name]= yield; },
       ]));
     } catch (Throwable $e) {
       throw new Error(500, 'UNEXPECTED: Streaming error', $e);

--- a/src/test/php/web/auth/unittest/CasFlowTest.class.php
+++ b/src/test/php/web/auth/unittest/CasFlowTest.class.php
@@ -224,7 +224,7 @@ class CasFlowTest extends FlowTest {
     $this->authenticate($fixture, '/?ticket='.self::TICKET);
   }
 
-  #[Test, Expect(class: Error::class, message: '/FORMAT: Validation cannot be parsed/')]
+  #[Test, Expect(class: Error::class, message: 'UNEXPECTED: []')]
   public function shows_error_when_validation_response_not_well_formed() {
     $fixture= new class(self::SSO) extends CasFlow {
       public function validate($ticket, $service) {


### PR DESCRIPTION
This reduces the PHP extension dependencies, DOM/XML is no longer required. Also, [xp-forge/address](https://github.com/xp-forge/address) is considerably smaller in code size than the old xp-framework/xml library