### PR TITLE
Make callback and scopes mutable

### DIFF
--- a/src/main/php/web/auth/oauth/OAuth2Flow.class.php
+++ b/src/main/php/web/auth/oauth/OAuth2Flow.class.php
@@ -44,6 +44,12 @@ class OAuth2Flow extends OAuthFlow {
   /** @return string[] */
   public function scopes() { return $this->scopes; }
 
+  /** @param string[] $scopes */
+  public function requesting($scopes): self {
+    $this->scopes= $scopes;
+    return $this;
+  }
+
   /**
    * Refreshes access token given a refresh token if necessary.
    *

--- a/src/main/php/web/auth/oauth/OAuthFlow.class.php
+++ b/src/main/php/web/auth/oauth/OAuthFlow.class.php
@@ -1,5 +1,6 @@
 <?php namespace web\auth\oauth;
 
+use util\URI;
 use web\auth\{Flow, UserInfo, AuthenticationError};
 
 abstract class OAuthFlow extends Flow {
@@ -7,6 +8,12 @@ abstract class OAuthFlow extends Flow {
 
   /** @return ?util.URI */
   public function callback() { return $this->callback; }
+
+  /** @param ?string|util.URI $callback */
+  public function calling($callback): self {
+    $this->callback= null === $callback || $callback instanceof URI ? $callback : new URI($callback);
+    return $this;
+  }
 
   /**
    * Returns user info which fetched from the given endpoint using the

--- a/src/test/php/web/auth/unittest/OAuth1FlowTest.class.php
+++ b/src/test/php/web/auth/unittest/OAuth1FlowTest.class.php
@@ -27,6 +27,14 @@ class OAuth1FlowTest extends FlowTest {
     Assert::equals(new URI(self::CALLBACK), (new OAuth1Flow(self::AUTH, [self::ID, self::SECRET], self::CALLBACK))->callback());
   }
 
+  #[Test]
+  public function calling() {
+    Assert::equals(
+      new URI('/test'),
+      (new OAuth1Flow(self::AUTH, [self::ID, self::SECRET], self::CALLBACK))->calling('/test')->callback()
+    );
+  }
+
   #[Test, Values(from: 'paths')]
   public function fetches_request_token_then_redirects_to_auth($path) {
     $request= ['oauth_token' => 'T'];

--- a/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
+++ b/src/test/php/web/auth/unittest/OAuth2FlowTest.class.php
@@ -52,9 +52,26 @@ class OAuth2FlowTest extends FlowTest {
   }
 
   #[Test]
+  public function calling() {
+    Assert::equals(
+      new URI('/test'),
+      (new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK))->calling('/test')->callback()
+    );
+  }
+
+  #[Test]
   public function scopes() {
     $scopes= ['user', 'profile'];
     Assert::equals($scopes, (new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK, $scopes))->scopes());
+  }
+
+  #[Test]
+  public function requesting_scopes() {
+    $scopes= ['user', 'profile'];
+    Assert::equals(
+      $scopes,
+      (new OAuth2Flow(self::AUTH, self::TOKENS, self::CONSUMER, self::CALLBACK))->requesting($scopes)->scopes()
+    );
   }
 
   #[Test]


### PR DESCRIPTION
* [x] Adds `OAuth1Flow::calling(string|util.URI $callback): self`
* [x] Adds `OAuth2Flow::calling(string|util.URI $callback): self`
* [x] Adds `OAuth2Flow::requesting(string[] $scopes): self`