### PR TITLE
Make it possible to change the session namespace

### DIFF
--- a/src/main/php/web/auth/oauth/OAuthFlow.class.php
+++ b/src/main/php/web/auth/oauth/OAuthFlow.class.php
@@ -4,7 +4,7 @@ use util\URI;
 use web\auth\{Flow, UserInfo, AuthenticationError};
 
 abstract class OAuthFlow extends Flow {
-  protected $callback;
+  protected $callback, $namespace;
 
   /** @return ?util.URI */
   public function callback() { return $this->callback; }
@@ -12,6 +12,12 @@ abstract class OAuthFlow extends Flow {
   /** @param ?string|util.URI $callback */
   public function calling($callback): self {
     $this->callback= null === $callback || $callback instanceof URI ? $callback : new URI($callback);
+    return $this;
+  }
+
+  /** @param string $namespace */
+  public function namespaced($namespace) {
+    $this->namespace= $namespace;
     return $this;
   }
 

--- a/src/main/php/web/auth/oauth/OAuthFlow.class.php
+++ b/src/main/php/web/auth/oauth/OAuthFlow.class.php
@@ -15,7 +15,13 @@ abstract class OAuthFlow extends Flow {
     return $this;
   }
 
-  /** @param string $namespace */
+  /**
+   * Sets session namespace for this flow. Used to prevent conflicts
+   * in session state with multiple OAuth flows in place.
+   *
+   * @param  string $namespace
+   * @return self
+   */
   public function namespaced($namespace) {
     $this->namespace= $namespace;
     return $this;
@@ -23,7 +29,7 @@ abstract class OAuthFlow extends Flow {
 
   /**
    * Returns user info which fetched from the given endpoint using the
-   * authorized OAuth2 client
+   * authorized OAuth client
    *
    * @param  string|util.URI $endpoint
    * @return web.auth.UserInfo


### PR DESCRIPTION
This way, multiple OAuth flows won't conflict in session state.